### PR TITLE
[feature-06/style] 엔빵 등록하기 페이지 퍼블리싱

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,10 @@ const nextConfig: NextConfig = {
     })
     return config
   },
+  // TODO 구글, 카카오 프로필 이미지 도메인 추가 필요
+  images: {
+    domains: ['avatars.githubusercontent.com'], // TODO 프로필 이미지 테스트용 임시 도메인, 수정 필요
+  },
 }
 
 export default nextConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.47.14",
+        "classnames": "^2.5.1",
         "next": "15.1.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.54.2",
         "tailwindcss-preset-px-to-rem": "^1.2.1",
         "zustand": "^5.0.3"
       },
@@ -3977,6 +3979,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -7340,6 +7348,22 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.47.14",
+    "classnames": "^2.5.1",
     "next": "15.1.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.54.2",
     "tailwindcss-preset-px-to-rem": "^1.2.1",
     "zustand": "^5.0.3"
   },

--- a/src/app/nbread/create/page.tsx
+++ b/src/app/nbread/create/page.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import DetailHeader from '@/components/common/header/detailHeader'
+import NbreadEditCard from '@/components/nbread/nbreadEditCard'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { Nbread } from '@/types/nbread'
+import classNames from 'classnames'
+import { useEffect } from 'react'
+import useNbreadStore from '@/stores/useNbreadStore'
+
+const Page = () => {
+  const router = useRouter()
+  const { setNbread } = useNbreadStore()
+  const nbread = useNbreadStore((state) => state.nbread)
+  const {
+    register,
+    setValue,
+    getValues,
+    handleSubmit,
+    reset,
+    formState: { isValid },
+  } = useForm<Nbread>({ mode: 'onChange' })
+
+  const onSubmit = (data: Nbread) => {
+    setNbread(data)
+    router.push('/nbread/preview')
+  }
+
+  useEffect(() => {
+    if (nbread !== null) {
+      reset(nbread)
+    }
+  }, [])
+
+  return (
+    <main className="flex h-full flex-col justify-between p-24">
+      <section>
+        <DetailHeader></DetailHeader>
+        <h3 className="pb-12 pt-20">엔빵 만들기 🍞</h3>
+        <NbreadEditCard
+          register={register}
+          setValue={setValue}
+          getValues={getValues}
+        />
+      </section>
+      <button
+        className={classNames('btn btn-large mb-20', {
+          'btn-disabled': !isValid,
+          'btn-primary': isValid,
+        })}
+        onClick={() => handleSubmit(onSubmit)()}
+        disabled={!isValid}
+      >
+        저장하기
+      </button>
+    </main>
+  )
+}
+
+export default Page

--- a/src/app/nbread/preview/page.tsx
+++ b/src/app/nbread/preview/page.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import DetailHeader from '@/components/common/header/detailHeader'
+import DashlineCard from '@/components/common/card/dashlineCard'
+import NbreadCard from '@/components/nbread/nbreadCard'
+import NbreadParticipantCard from '@/components/nbread/nbreadParticipantCard'
+import useNbreadStore from '@/stores/useNbreadStore'
+import { Nbread } from '@/types/nbread'
+
+const Page = () => {
+  const nbreadData = useNbreadStore((state) => state.nbread)
+
+  return (
+    <main className="h-full-y-auto relative p-24">
+      <section className="stick">
+        <DetailHeader />
+        <div className="pt-20 text-body03 text-gray-400">
+          작성한 엔빵의 미리보기에요.
+        </div>
+        <h2 className="pb-12 pt-4">{nbreadData?.title}</h2>
+        <NbreadCard nbreadData={nbreadData as Nbread} />
+        <div className="mb-12 mt-40 text-body02 text-gray-500">참여한 사람</div>
+        <div className="mb-40 flex flex-col gap-8">
+          {/* TODO 로그인 기능 구현 후 데이터 수정 필요 */}
+          <NbreadParticipantCard isNbreadLeader={true} name={'신혜민'} />
+          <DashlineCard
+            text="친구는 엔빵을 만든 후 초대할 수 있어요."
+            iconType="warning"
+            size={12}
+            tailwindColor="text-gray-00"
+          />
+        </div>
+        <button
+          className="btn btn-large btn-primary mb-20"
+          onClick={() => null}
+        >
+          엔빵 만들기 🍞
+        </button>
+      </section>
+    </main>
+  )
+}
+export default Page

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
-import Icon from '@/components/common/icon/Icon'
+import Icon from '@/components/common/icon/icon'
 
 export default function Page() {
   return (
-    <div>
+    <div className="p-24">
       <h1>heading-01 24px</h1>
       <h2>heading-02 20px</h2>
       <h3>heading-03 18px</h3>

--- a/src/components/common/avatar/avatar.tsx
+++ b/src/components/common/avatar/avatar.tsx
@@ -1,0 +1,43 @@
+import DefaultAvatar from '@/assets/avatar.svg'
+import Image from 'next/image'
+import Icon from '../icon/icon'
+
+const avatarSizeMap = { small: 24, large: 32 } as const
+
+interface AvatarProps {
+  size: keyof typeof avatarSizeMap
+  profileImageUrl?: string
+  isNbreadLeader?: boolean
+}
+
+const Avatar = ({ size, profileImageUrl, isNbreadLeader }: AvatarProps) => {
+  const avatarSize = avatarSizeMap[size]
+
+  return (
+    <div className="relative">
+      {profileImageUrl ? (
+        <Image
+          alt="프로필 이미지"
+          src={profileImageUrl}
+          className="rounded-40"
+          width={avatarSize}
+          height={avatarSize}
+        />
+      ) : (
+        <DefaultAvatar
+          width={avatarSize}
+          height={avatarSize}
+          aria-label={'프로필 이미지'}
+          viewBox="0 0 36 36"
+        />
+      )}
+      {isNbreadLeader && (
+        <div className="absolute bottom-0 right-0">
+          <Icon type="badge" width={12} height={12} fill="text-secondary-200" />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Avatar

--- a/src/components/common/card/dashlineCard.tsx
+++ b/src/components/common/card/dashlineCard.tsx
@@ -1,0 +1,29 @@
+import Icon, { IconType } from '../icon/icon'
+
+interface DashlineCardProps {
+  text: string
+  tailwindColor: string
+  iconType: IconType
+  size: number
+  onClick?: () => void
+}
+
+const DashlineCard = ({
+  text,
+  tailwindColor,
+  iconType,
+  size,
+  onClick,
+}: DashlineCardProps) => {
+  return (
+    <div
+      className="card-dashline flex flex-row items-center justify-center gap-8 px-32 py-26"
+      onClick={onClick}
+    >
+      <Icon type={iconType} width={size} height={size} fill={tailwindColor} />
+      <div className="text-body02">{text}</div>
+    </div>
+  )
+}
+
+export default DashlineCard

--- a/src/components/common/header/detailHeader.tsx
+++ b/src/components/common/header/detailHeader.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import Icon from '../icon/icon'
+
+export default function DetailHeader() {
+  const router = useRouter()
+
+  return (
+    <header className="h-48 w-full pt-16">
+      <div onClick={() => router.back()}>
+        <Icon
+          type="angleLeft"
+          width={16}
+          height={16}
+          fill="text-gray-600"
+        ></Icon>
+      </div>
+    </header>
+  )
+}

--- a/src/components/common/icon/Icon.tsx
+++ b/src/components/common/icon/Icon.tsx
@@ -27,7 +27,7 @@ const iconMap = {
 } as const
 
 // iconMap의 key를 type으로 변경
-type IconType = keyof typeof iconMap
+export type IconType = keyof typeof iconMap
 
 interface IconProps {
   type: IconType

--- a/src/components/common/tab/tab.tsx
+++ b/src/components/common/tab/tab.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import classNames from 'classnames'
+
+interface TabProps {
+  content: string
+  isClicked?: boolean
+  onClick: () => void
+}
+
+const Tab = ({ content, isClicked, onClick }: TabProps) => {
+  return (
+    <div
+      className={classNames('badge', {
+        'badge-selected': isClicked,
+        'badge-disabled': !isClicked,
+      })}
+      onClick={() => {
+        onClick()
+      }}
+    >
+      {content}
+    </div>
+  )
+}
+
+export default Tab

--- a/src/components/common/tabbar/tabbar.tsx
+++ b/src/components/common/tabbar/tabbar.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState } from 'react'
+import Tab from '../tab/tab'
+
+interface TabbarProps {
+  tabs: string[]
+  initialValue?: number
+  onTabChange: (index: number) => void
+}
+
+const Tabbar = ({ tabs, initialValue, onTabChange }: TabbarProps) => {
+  const [selectedTab, setSelectedTab] = useState<number>(initialValue || 0)
+
+  const handleTabChange = (index: number) => {
+    setSelectedTab(index)
+    onTabChange(index)
+  }
+
+  return (
+    <div className="flex flex-row gap-4">
+      {tabs.map((tab, index) => (
+        <Tab
+          key={index}
+          isClicked={selectedTab === index}
+          content={tab}
+          onClick={() => handleTabChange(index)}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default Tabbar

--- a/src/components/nbread/nbreadCard.tsx
+++ b/src/components/nbread/nbreadCard.tsx
@@ -1,0 +1,43 @@
+import { Nbread } from '@/types/nbread'
+
+interface NbreadCardProps {
+  nbreadData: Nbread
+}
+
+const NbreadCard = ({ nbreadData }: NbreadCardProps) => {
+  return (
+    <>
+      <div className="card px-24 pb-32">
+        <div className="pb-4 text-body03 text-gray-600">총 금액</div>
+        <div className="text-heading01 text-secondary-200">
+          {Number(nbreadData.amount).toLocaleString()}원
+        </div>
+        <hr className="mt-20 border-gray-100" />
+        <div className="flex flex-col gap-16 pt-20">
+          <div className="flex flex-row items-center justify-between">
+            <div className="w-120 text-body02 text-gray-500">참여 인원</div>
+            <div className="text-body02 text-gray-800">
+              {nbreadData.participantCount}명
+            </div>
+          </div>
+          <div className="flex flex-row items-center justify-between">
+            <div className="w-120 text-body02 text-gray-500">엔빵 금액</div>
+            <div className="text-body02 text-gray-800">
+              {nbreadData.paymentAmount.toLocaleString()}원
+            </div>
+          </div>
+          <div className="flex flex-row items-center justify-between">
+            <div className="w-120 text-body02 text-gray-500">정기 결제일</div>
+            <div className="text-body02 text-gray-800">
+              {nbreadData.paymentPeriod === 'year'
+                ? `매년 ${nbreadData.paymentMonth}월 ${nbreadData.paymentDate}일`
+                : `매월 ${nbreadData.paymentDate}일`}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default NbreadCard

--- a/src/components/nbread/nbreadEditCard.tsx
+++ b/src/components/nbread/nbreadEditCard.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import useNbreadStore from '@/stores/useNbreadStore'
+import Tabbar from '../common/tabbar/tabbar'
+import { Nbread } from '@/types/nbread'
+import { useEffect, useState } from 'react'
+import {
+  UseFormGetValues,
+  UseFormRegister,
+  UseFormSetValue,
+} from 'react-hook-form'
+
+interface NbreadEditCardProps {
+  register: UseFormRegister<Nbread>
+  setValue: UseFormSetValue<Nbread>
+  getValues: UseFormGetValues<Nbread>
+}
+
+const NbreadEditCard = ({
+  register,
+  setValue,
+  getValues,
+}: NbreadEditCardProps) => {
+  const nbread = useNbreadStore((state) => state.nbread)
+  const [amount, setAmount] = useState<number | undefined>(
+    nbread ? nbread.amount : 0,
+  )
+  const [participantCount, setParticipantCount] = useState<number>(
+    nbread ? nbread.participantCount : 1,
+  )
+  const [selectedTabIndex, setSelectedTabIndex] = useState<number>(
+    nbread ? (nbread.paymentPeriod === 'year' ? 0 : 1) : 0,
+  )
+
+  const paymentPeriodTab = ['매년', '매월']
+  const paymentPeriodValue = ['year', 'month']
+
+  useEffect(() => {
+    const selectedPaymentPeriod = paymentPeriodValue[selectedTabIndex] as
+      | 'year'
+      | 'month'
+    setValue('paymentPeriod', selectedPaymentPeriod)
+
+    if (selectedPaymentPeriod === 'month') {
+      setValue('paymentMonth', null)
+    }
+  }, [selectedTabIndex])
+
+  useEffect(() => {
+    const calculatedValue =
+      amount && participantCount ? Math.round(amount / participantCount) : 0
+
+    if (getValues('paymentAmount') !== calculatedValue) {
+      setValue('paymentAmount', calculatedValue)
+    }
+  }, [amount, participantCount, getValues, setValue])
+
+  return (
+    <>
+      <div className="card px-24 pb-32">
+        {/* ------------ 총 금액 ------------ */}
+        <div className="pb-4 text-body03 text-gray-400">총 금액</div>
+        <input
+          {...register('amount', {
+            onChange: (event) => setAmount(Number(event?.target.value)),
+            required: '총 금액은 필수 입력 항목이에요.',
+          })}
+          type="number"
+          className="text-heading02 text-secondary-200"
+          placeholder="총 금액을 입력하세요"
+        />
+        <div className="flex flex-col gap-16 pt-32">
+          {/* ------------ 타이틀 ------------ */}
+          <div className="flex flex-row items-center justify-between">
+            <div className="w-120 text-body02 text-gray-500">타이틀</div>
+            <input
+              {...register('title', {
+                required: '타이틀은 필수 입력 항목이에요.',
+              })}
+              className="w-200 text-body02 text-gray-800"
+              placeholder="타이틀을 입력해주세요"
+            />
+          </div>
+          {/* ------------ 참여 인원 ------------ */}
+          <div className="flex flex-row items-center justify-between">
+            <div className="w-120 text-body02 text-gray-500">참여 인원</div>
+            <select
+              className="w-200 text-body02"
+              {...register('participantCount', {
+                onChange: (event) =>
+                  setParticipantCount(Number(event.target.value)),
+              })}
+            >
+              {Array.from({ length: 10 }, (_, i) => (
+                <option key={i + 1} value={i + 1}>
+                  {i + 1}명
+                </option>
+              ))}
+            </select>
+          </div>
+          {/* ------------ 엔빵 금액 ------------ */}
+          <div className="flex flex-row items-center justify-between">
+            <div className="w-120 text-body02 text-gray-500">엔빵 금액</div>
+            <input
+              {...register('paymentAmount')}
+              className="w-200 text-body02 text-gray-400"
+              placeholder="0"
+              disabled={true}
+            />
+          </div>
+          {/* ------------ 결제 주기 ------------ */}
+          <div className="flex flex-row items-center justify-between">
+            <div className="w-120 text-body02 text-gray-500">결제 주기</div>
+            <Tabbar
+              tabs={paymentPeriodTab}
+              initialValue={selectedTabIndex}
+              onTabChange={setSelectedTabIndex}
+            />
+          </div>
+          {/* ------------ 결제월 ------------ */}
+          {paymentPeriodTab[selectedTabIndex] === '매년' && (
+            <div className="flex flex-row items-center justify-between">
+              <div className="w-120 text-body02 text-gray-500">정기 결제월</div>
+              <select
+                className="w-200 text-body02"
+                {...register('paymentMonth')}
+              >
+                {Array.from({ length: 12 }, (_, i) => (
+                  <option key={i + 1} value={i + 1}>
+                    {i + 1}월
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          {/* ------------ 결제일 ------------ */}
+          <div className="flex flex-row items-center justify-between">
+            <div className="w-120 text-body02 text-gray-500">정기 결제일</div>
+            <select className="w-200 text-body02" {...register('paymentDate')}>
+              {Array.from({ length: 30 }, (_, i) => (
+                <option key={i + 1} value={i + 1}>
+                  {i + 1}일
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default NbreadEditCard

--- a/src/components/nbread/nbreadParticipantCard.tsx
+++ b/src/components/nbread/nbreadParticipantCard.tsx
@@ -1,0 +1,31 @@
+import Avatar from '../common/avatar/avatar'
+
+interface NbreadParticipantCardProps {
+  profileImageUrl?: string
+  isNbreadLeader: boolean
+  name: string
+  paymentAmount?: string
+  hasCheckbox?: boolean
+  isChecked?: boolean
+  isCheckable?: boolean
+  handleClickCheckbox?: () => void
+  hasDelete?: boolean
+  handleClickDelete?: () => void
+}
+
+const NbreadParticipantCard = (props: NbreadParticipantCardProps) => {
+  return (
+    <div className="card align-center flex flex-row items-center gap-16">
+      <div className="w-40">
+        <Avatar
+          profileImageUrl={props.profileImageUrl}
+          size="large"
+          isNbreadLeader={props.isNbreadLeader}
+        />
+      </div>
+      <div className="text-body01 text-gray-800">{props.name}</div>
+    </div>
+  )
+}
+
+export default NbreadParticipantCard

--- a/src/stores/useNbreadStore.tsx
+++ b/src/stores/useNbreadStore.tsx
@@ -1,0 +1,14 @@
+import { Nbread } from '@/types/nbread'
+import { create } from 'zustand'
+
+interface NbreadStore {
+  nbread: Nbread | null
+  setNbread: (nbread: Nbread | null) => void
+}
+
+const useNbreadStore = create<NbreadStore>()((set) => ({
+  nbread: null,
+  setNbread: (nbread) => set({ nbread: nbread }),
+}))
+
+export default useNbreadStore

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,17 +3,51 @@
 @tailwind utilities;
 
 /* 기본 레이아웃 설정 */
+html {
+  @apply overflow-y-hidden;
+}
+
 html,
 body {
-  @apply mx-auto min-h-screen min-w-[320px] max-w-[600px] overflow-x-hidden bg-white shadow-[0_7px_29px_0_rgba(100,100,111,0.1)];
+  @apply mx-auto h-[100svh] min-h-screen min-w-[320px] max-w-[600px] overflow-x-hidden bg-white shadow-[0_7px_29px_0_rgba(100,100,111,0.1)];
 }
 
 body {
-  @apply bg-background p-24 font-pretendard text-gray-800 antialiased;
+  @apply h-[100svh] bg-background font-pretendard text-gray-800 antialiased;
+}
+
+input {
+  @apply w-full border-0 border-gray-200 bg-transparent p-4 text-gray-800 transition-all duration-200;
+  border-bottom: 1px solid theme('colors.gray.200');
+}
+
+input:focus {
+  outline: none;
+  border-bottom: 1.6px solid theme('colors.primary.500');
+}
+
+input[type='number']::-webkit-inner-spin-button,
+input[type='number']::-webkit-outer-spin-button {
+  @apply hidden;
+}
+
+input[type='date']::-webkit-calendar-picker-indicator {
+  display: none;
 }
 
 * {
   @apply m-0 p-0;
+}
+
+select {
+  @apply w-full p-2;
+  outline: none;
+  border-bottom: 1px solid theme('colors.gray.200');
+}
+
+select:focus {
+  outline: none;
+  border-bottom: 1.6px solid theme('colors.primary.500');
 }
 
 a {
@@ -45,32 +79,53 @@ a {
     box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.12); /* 직접 box-shadow 적용 */
   }
 
+  .card-dashline {
+    @apply rounded-8 p-20 text-body01 text-gray-300;
+    background-image: url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='8' ry='8' stroke='%23C9C9CAFF' stroke-width='3' stroke-dasharray='8%2c 8' stroke-dashoffset='0' stroke-linecap='butt'/%3e%3c/svg%3e");
+  }
+
   .btn {
-    @apply rounded-8 cursor-pointer;
+    @apply cursor-pointer rounded-8;
   }
 
   .btn-small {
-    @apply w-148 h-48 text-heading05;
+    @apply h-48 w-148 text-heading05;
   }
 
   .btn-medium {
-    @apply w-232 h-48 text-heading05;
+    @apply h-48 w-232 text-heading05;
   }
 
   .btn-large {
-    @apply min-w-280 h-56 w-full text-heading04;
+    @apply h-56 w-full min-w-280 text-heading04;
   }
 
   /* 유형별 스타일 */
   .btn-primary {
-    @apply bg-secondary-100 text-white active:bg-secondary-200;
+    @apply bg-secondary-100 text-white hover:bg-primary-500 active:bg-secondary-200;
   }
 
   .btn-secondary {
-    @apply bg-gray-200 text-gray-700 active:bg-gray-300;
+    @apply bg-gray-300 text-gray-800 hover:bg-gray-200 active:bg-gray-400;
   }
 
   .btn-warning {
     @apply bg-system-red text-white;
+  }
+
+  .btn-disabled {
+    @apply bg-gray-300 text-gray-500;
+  }
+
+  .badge {
+    @apply shadow-avatar cursor-pointer rounded-40 px-8 py-4 text-body03 transition-all duration-200;
+  }
+
+  .badge-selected {
+    @apply bg-primary-100 text-primary-500;
+  }
+
+  .badge-disabled {
+    @apply bg-gray-200 text-gray-400;
   }
 }

--- a/src/types/nbread.ts
+++ b/src/types/nbread.ts
@@ -1,0 +1,11 @@
+// TODO) 엔빵 타입 별도 선언 + 테이블 만들어지면 추가로 수정 필요
+export interface Nbread {
+  id: string
+  title: string
+  participantCount: number
+  amount: number
+  paymentAmount: number
+  paymentPeriod: 'year' | 'month'
+  paymentMonth: number | null
+  paymentDate: number | null
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #9 

## 📝작업 내용

**1. 엔빵 등록하기 페이지 퍼블리싱**
> 엔빵 등록하기 페이지 및 관련 컴포넌트 퍼블리싱을 완료했습니다.
> 엔빵 등록 시 react-hook-form을 사용해 유효성을 검사하고, 유효하지 않을 경우 버튼이 비활성화되도록 구현했습니다.

**2. 엔빵 미리보기 페이지 퍼블리싱**
> 엔빵 미리보기 페이지 및 관련 컴포넌트 퍼블리싱을 완료했습니다.
> 엔빵 등록하기 페이지에서 저장한 정보가 미리보기 페이지에서 보일 수 있도록 구현했습니다.

**3. 엔빵 type 및 useNbreadStore 구현**
> nbread.ts에 Nbread type을 구현했습니다.
> useNbreadStore를 구현해 엔빵 등록하기 페이지와 미리보기 페이지에서 작성한 정보를 공유할 수 있게 하였습니다.

**4. globals.css body 패딩 제거**
> globals.css의 body에 적용되어 있던 패딩을 제거했습니다.
> globals.css의 body에 패딩을 적용할 경우, 각 페이지 내에서 호출한 컴포넌트의 shadow가 잘려서 보이는 문제가 있어,
> body에 적용되어 있던 패딩을 제거하고 각 페이지 별로 각각 패딩을 추가하는 방식으로 변경했습니다.

**5. NETX Image 허용 도메인 및 의존성 추가**
> NEXT의 Image 컴포넌트의 src 속성에 허용할 임시 도메인을 추가했습니다. _(추후 카카오톡, 구글 프로필 사진 도메인 추가 필요)_
> react-hook-form, classnames 라이브러리를 추가했습니다.


### 스크린샷
![스크린샷 2025-02-19 오후 5 56 34](https://github.com/user-attachments/assets/be33cc86-9542-45d0-9046-c842a04bf5f6)
![스크린샷 2025-02-19 오후 5 56 51](https://github.com/user-attachments/assets/d0fe7b3e-513e-4e22-800b-1226955da160)


## 💬리뷰 요구사항(선택)
**1. import 오류**
> 파일명을 대소문자만 변경할 경우 import문에서 오류가 발생하는 이슈가 있습니다.
> 일단 모든 파일명은 소문자로 작성했고, 추후 `/components` 디렉토리의 파일명만 대문자로 일괄 수정하려고 합니다.
> 구글링했을 때 파일명을 아예 다른 문자로 바꿨다가 다시 원래대로 바꾸면 오류가 안 난다고 해서 적용해 봤는데,
> import 오류가 안 사라지네요... (mac OS라서 그런 것으로 예상)

**2. globals.css body 패딩 제거 시 레이아웃 깨짐 문제**
> 컴포넌트 그림자가 잘려서 보이는 문제 때문에 globals.css body의 패딩을 제거했는데,
> 이러면 dev 브랜치를 pull 받을 경우 기존에 작업하시던 페이지들의 레이아웃이 깨질 수 있습니다.
> 작업하던 page 컴포넌트의 최상위 태그에 p-24를 넣어주시면 해결됩니다.