### PR TITLE
[feature-09/style] 엔빵 상세보기/수정하기 페이지 퍼블리싱

### DIFF
--- a/src/app/nbread/create/page.tsx
+++ b/src/app/nbread/create/page.tsx
@@ -12,7 +12,7 @@ import useNbreadStore from '@/stores/useNbreadStore'
 const Page = () => {
   const router = useRouter()
   const { setNbread } = useNbreadStore()
-  const nbread = useNbreadStore((state) => state.nbread)
+  const nbreadFormData = useNbreadStore((state) => state.nbread)
   const {
     register,
     setValue,
@@ -28,8 +28,8 @@ const Page = () => {
   }
 
   useEffect(() => {
-    if (nbread !== null) {
-      reset(nbread)
+    if (nbreadFormData !== null) {
+      reset(nbreadFormData)
     }
   }, [])
 
@@ -42,6 +42,7 @@ const Page = () => {
           register={register}
           setValue={setValue}
           getValues={getValues}
+          defaultNbreadValue={nbreadFormData || undefined}
         />
       </section>
       <button

--- a/src/app/nbread/detail/page.tsx
+++ b/src/app/nbread/detail/page.tsx
@@ -45,7 +45,6 @@ const Page = () => {
 
   useEffect(() => {
     reset(nbreadDummyData)
-    console.log(nbreadDummyData)
   }, [])
 
   return (

--- a/src/app/nbread/detail/page.tsx
+++ b/src/app/nbread/detail/page.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import DetailHeader from '@/components/common/header/detailHeader'
+import Tab from '@/components/common/tab/tab'
+import NbreadCard from '@/components/nbread/nbreadCard'
+import NbreadEditCard from '@/components/nbread/nbreadEditCard'
+import NbreadParticipantsList from '@/components/nbread/nbreadParticipantsList'
+import { Nbread } from '@/types/nbread'
+import { User } from '@/types/user'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+// TODO 기능 구현 후 더미데이터 삭제
+const dummyUser: User = {
+  id: '1',
+  name: '신혜민',
+  socialType: 'kakao',
+  profileImage: null,
+  email: 'shinhm1@naver.com',
+}
+
+const nbreadDummyData: Nbread = {
+  id: '1',
+  title: '나의 인도 가좍',
+  participantCount: 5,
+  amount: 80000,
+  paymentAmount: 80000 / 5,
+  paymentPeriod: 'year',
+  paymentMonth: 8,
+  paymentDate: 1,
+  leaderId: '1',
+  participants: [{ user: dummyUser, isLeader: true }],
+}
+
+const Page = () => {
+  const [isEditing, setIsEditing] = useState<boolean>(false)
+  const {
+    register,
+    setValue,
+    getValues,
+    // handleSubmit,
+    reset,
+    // formState: { isValid },
+  } = useForm<Nbread>({ mode: 'onChange' })
+
+  useEffect(() => {
+    reset(nbreadDummyData)
+    console.log(nbreadDummyData)
+  }, [])
+
+  return (
+    <main className="h-full-y-auto relative p-24">
+      <section>
+        <DetailHeader />
+        <div className="flex flex-row items-center justify-between pb-12 pt-24">
+          <h2 className="">
+            {isEditing ? '엔빵 수정하기' : nbreadDummyData?.title}
+          </h2>
+          <div className="h-20">
+            <Tab
+              content={isEditing ? '저장하기' : '수정하기'}
+              size="large"
+              isClicked={isEditing}
+              onClick={() => setIsEditing(!isEditing)}
+            />
+          </div>
+        </div>
+        {isEditing ? (
+          <NbreadEditCard
+            register={register}
+            setValue={setValue}
+            getValues={getValues}
+            defaultNbreadValue={nbreadDummyData}
+          />
+        ) : (
+          <NbreadCard nbreadData={nbreadDummyData as Nbread} />
+        )}
+        <NbreadParticipantsList
+          participants={nbreadDummyData.participants!}
+          participantMaxCount={nbreadDummyData.participantCount}
+          leaderId={nbreadDummyData.leaderId!}
+          isEditing={isEditing}
+          paymentAmount={nbreadDummyData.paymentAmount}
+        />
+      </section>
+    </main>
+  )
+}
+
+export default Page

--- a/src/components/common/checkbox/checkbox.tsx
+++ b/src/components/common/checkbox/checkbox.tsx
@@ -1,0 +1,16 @@
+interface CheckboxProps {
+  disabled?: boolean
+  isChecked?: boolean
+  onClick: () => void
+}
+
+const Checkbox = ({ disabled, isChecked, onClick }: CheckboxProps) => {
+  return (
+    <label className="checkbox_label h-16" onClick={onClick}>
+      <input type="checkbox" disabled={disabled || false} checked={isChecked} />
+      <span className="checkbox_icon" />
+    </label>
+  )
+}
+
+export default Checkbox

--- a/src/components/common/header/detailHeader.tsx
+++ b/src/components/common/header/detailHeader.tsx
@@ -8,13 +8,8 @@ export default function DetailHeader() {
 
   return (
     <header className="h-48 w-full pt-16">
-      <div onClick={() => router.back()}>
-        <Icon
-          type="angleLeft"
-          width={16}
-          height={16}
-          fill="text-gray-600"
-        ></Icon>
+      <div className="cursor-pointer" onClick={() => router.back()}>
+        <Icon type="angleLeft" width={16} height={16} fill="text-gray-600" />
       </div>
     </header>
   )

--- a/src/components/common/tab/tab.tsx
+++ b/src/components/common/tab/tab.tsx
@@ -3,18 +3,26 @@
 import classNames from 'classnames'
 
 interface TabProps {
+  size: 'small' | 'large'
   content: string
   isClicked?: boolean
   onClick: () => void
 }
 
-const Tab = ({ content, isClicked, onClick }: TabProps) => {
+const Tab = ({ content, size, isClicked, onClick }: TabProps) => {
   return (
     <div
-      className={classNames('badge', {
-        'badge-selected': isClicked,
-        'badge-disabled': !isClicked,
-      })}
+      className={classNames(
+        'badge',
+        {
+          'badge-selected': isClicked,
+          'badge-disabled': !isClicked,
+        },
+        {
+          'badge-small': size === 'small',
+          'badge-large': size === 'large',
+        },
+      )}
       onClick={() => {
         onClick()
       }}

--- a/src/components/common/tabbar/tabbar.tsx
+++ b/src/components/common/tabbar/tabbar.tsx
@@ -24,6 +24,7 @@ const Tabbar = ({ tabs, initialValue, onTabChange }: TabbarProps) => {
           key={index}
           isClicked={selectedTab === index}
           content={tab}
+          size="small"
           onClick={() => handleTabChange(index)}
         />
       ))}

--- a/src/components/nbread/nbreadEditCard.tsx
+++ b/src/components/nbread/nbreadEditCard.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import useNbreadStore from '@/stores/useNbreadStore'
 import Tabbar from '../common/tabbar/tabbar'
 import { Nbread } from '@/types/nbread'
 import { useEffect, useState } from 'react'
@@ -14,22 +13,27 @@ interface NbreadEditCardProps {
   register: UseFormRegister<Nbread>
   setValue: UseFormSetValue<Nbread>
   getValues: UseFormGetValues<Nbread>
+  defaultNbreadValue?: Nbread
 }
 
 const NbreadEditCard = ({
   register,
   setValue,
   getValues,
+  defaultNbreadValue,
 }: NbreadEditCardProps) => {
-  const nbread = useNbreadStore((state) => state.nbread)
   const [amount, setAmount] = useState<number | undefined>(
-    nbread ? nbread.amount : 0,
+    defaultNbreadValue ? defaultNbreadValue.amount : 0,
   )
   const [participantCount, setParticipantCount] = useState<number>(
-    nbread ? nbread.participantCount : 1,
+    defaultNbreadValue ? defaultNbreadValue.participantCount : 1,
   )
   const [selectedTabIndex, setSelectedTabIndex] = useState<number>(
-    nbread ? (nbread.paymentPeriod === 'year' ? 0 : 1) : 0,
+    defaultNbreadValue
+      ? defaultNbreadValue.paymentPeriod === 'year'
+        ? 0
+        : 1
+      : 0,
   )
 
   const paymentPeriodTab = ['매년', '매월']

--- a/src/components/nbread/nbreadEditCard.tsx
+++ b/src/components/nbread/nbreadEditCard.tsx
@@ -36,6 +36,11 @@ const NbreadEditCard = ({
       : 0,
   )
 
+  const participantCountMinValue = Math.max(
+    1,
+    defaultNbreadValue?.participants?.length || 0,
+  )
+
   const paymentPeriodTab = ['매년', '매월']
   const paymentPeriodValue = ['year', 'month']
 
@@ -95,11 +100,17 @@ const NbreadEditCard = ({
                   setParticipantCount(Number(event.target.value)),
               })}
             >
-              {Array.from({ length: 10 }, (_, i) => (
-                <option key={i + 1} value={i + 1}>
-                  {i + 1}명
-                </option>
-              ))}
+              {Array.from(
+                { length: 10 - participantCountMinValue + 1 },
+                (_, i) => (
+                  <option
+                    key={participantCountMinValue + i}
+                    value={participantCountMinValue + i}
+                  >
+                    {participantCountMinValue + i}명
+                  </option>
+                ),
+              )}
             </select>
           </div>
           {/* ------------ 엔빵 금액 ------------ */}

--- a/src/components/nbread/nbreadParticipantCard.tsx
+++ b/src/components/nbread/nbreadParticipantCard.tsx
@@ -1,29 +1,52 @@
 import Avatar from '../common/avatar/avatar'
+import Checkbox from '../common/checkbox/checkbox'
+import Icon from '../common/icon/icon'
 
 interface NbreadParticipantCardProps {
   profileImageUrl?: string
   isNbreadLeader: boolean
   name: string
-  paymentAmount?: string
+  paymentAmount?: number
   hasCheckbox?: boolean
   isChecked?: boolean
-  isCheckable?: boolean
-  handleClickCheckbox?: () => void
+  isCheckboxDisabled?: boolean
+  onClickCheckbox?: () => void
   hasDelete?: boolean
-  handleClickDelete?: () => void
+  onClickDelete?: () => void
 }
 
 const NbreadParticipantCard = (props: NbreadParticipantCardProps) => {
   return (
-    <div className="card align-center flex flex-row items-center gap-16">
-      <div className="w-40">
-        <Avatar
-          profileImageUrl={props.profileImageUrl}
-          size="large"
-          isNbreadLeader={props.isNbreadLeader}
-        />
+    <div className="card flex flex-row items-center justify-between">
+      <div className="align-center flex flex-row items-center gap-16">
+        <div className="w-40">
+          <Avatar
+            profileImageUrl={props.profileImageUrl}
+            size="large"
+            isNbreadLeader={props.isNbreadLeader}
+          />
+        </div>
+        <div className="text-body01 text-gray-800">{props.name}</div>
+        {props.hasCheckbox && (
+          <div className="text-body02 text-gray-400">{`${props.paymentAmount?.toLocaleString()}원`}</div>
+        )}
       </div>
-      <div className="text-body01 text-gray-800">{props.name}</div>
+      {props.hasCheckbox && (
+        <Checkbox
+          disabled={props.isCheckboxDisabled}
+          isChecked={props.isChecked}
+          onClick={() => props.onClickCheckbox && props.onClickCheckbox()}
+        />
+      )}
+      {props.hasDelete && (
+        <Icon
+          type="cross"
+          width={16}
+          height={16}
+          fill="text-gray-500"
+          onClick={props.onClickDelete}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/nbread/nbreadParticipantsList.tsx
+++ b/src/components/nbread/nbreadParticipantsList.tsx
@@ -1,0 +1,55 @@
+import { Participant } from '@/types/nbread'
+import NbreadParticipantCard from './nbreadParticipantCard'
+import DashlineCard from '../common/card/dashlineCard'
+
+interface NbreadParticipantsListProps {
+  participants: Participant[]
+  participantMaxCount: number
+  paymentAmount: number
+  isEditing: boolean
+  leaderId: string
+}
+
+const NbreadParticipantsList = ({
+  participants,
+  participantMaxCount,
+  paymentAmount,
+  isEditing,
+  leaderId,
+}: NbreadParticipantsListProps) => {
+  return (
+    <section>
+      <div className="mb-12 mt-40 text-body02 text-gray-500">참여한 사람</div>
+      <div className="mb-40 flex flex-col gap-8">
+        {Array.from({ length: participantMaxCount }).map((_, index) =>
+          participants && index < participants.length ? (
+            <NbreadParticipantCard
+              key={index}
+              isNbreadLeader={true}
+              name={participants[index].user.name}
+              paymentAmount={paymentAmount}
+              hasCheckbox={!isEditing}
+              // TODO 기능 구현 후 ID 하드코딩 값 수정 필요
+              isCheckboxDisabled={
+                leaderId !== '1' && participants[index].user.id !== '1'
+              }
+              hasDelete={isEditing && participants[index].user.id !== '1'}
+              onClickDelete={() => console.log('엔빵 멤버 삭제 모달 오픈')}
+            />
+          ) : (
+            <DashlineCard
+              key={index}
+              text="친구 추가하기"
+              iconType="plus"
+              size={10}
+              tailwindColor="text-gray-00"
+              onClick={() => console.log('친구 초대하기 모달 열기')}
+            />
+          ),
+        )}
+      </div>
+    </section>
+  )
+}
+
+export default NbreadParticipantsList

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,6 +3,7 @@
 @tailwind utilities;
 
 /* 기본 레이아웃 설정 */
+/* 기본 레이아웃 설정 */
 html {
   @apply overflow-y-hidden;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,7 +3,6 @@
 @tailwind utilities;
 
 /* 기본 레이아웃 설정 */
-/* 기본 레이아웃 설정 */
 html {
   @apply overflow-y-hidden;
 }
@@ -16,6 +15,8 @@ body {
 body {
   @apply h-[100svh] bg-background font-pretendard text-gray-800 antialiased;
 }
+
+/* 기본 태그 스타일 초기화 및 커스터마이징 */
 
 input {
   @apply w-full border-0 border-gray-200 bg-transparent p-4 text-gray-800 transition-all duration-200;
@@ -34,6 +35,44 @@ input[type='number']::-webkit-outer-spin-button {
 
 input[type='date']::-webkit-calendar-picker-indicator {
   display: none;
+}
+
+input[type='checkbox'] {
+  display: none;
+}
+
+.checkbox_icon::before {
+  content: '';
+  display: block;
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  background-color: transparent;
+  border: 1px solid theme('colors.secondary.200');
+  border-radius: 40px;
+  box-sizing: border-box;
+  position: relative;
+  cursor: pointer;
+}
+
+.checkbox_label input:checked + .checkbox_icon::before {
+  transition: all 0.15s ease;
+  background: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e")
+    theme('colors.secondary.200') no-repeat center;
+  border: none;
+}
+
+.checkbox_label input:disabled + .checkbox_icon::before {
+  background-color: theme('colors.gray.200');
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.checkbox_label input:checked:disabled + .checkbox_icon::before {
+  background: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e")
+    theme('colors.gray.200') no-repeat center;
+  border: none;
+  opacity: 0.6;
 }
 
 * {
@@ -119,7 +158,15 @@ a {
   }
 
   .badge {
-    @apply shadow-avatar cursor-pointer rounded-40 px-8 py-4 text-body03 transition-all duration-200;
+    @apply shadow-avatar cursor-pointer rounded-40 px-8 py-4 transition-all duration-200;
+  }
+
+  .badge-small {
+    @apply text-body03;
+  }
+
+  .badge-large {
+    @apply text-body02;
   }
 
   .badge-selected {

--- a/src/types/nbread.ts
+++ b/src/types/nbread.ts
@@ -1,4 +1,4 @@
-// TODO) 엔빵 타입 별도 선언 + 테이블 만들어지면 추가로 수정 필요
+import { User } from '@/types/user'
 export interface Nbread {
   id: string
   title: string
@@ -8,4 +8,11 @@ export interface Nbread {
   paymentPeriod: 'year' | 'month'
   paymentMonth: number | null
   paymentDate: number | null
+  leaderId: string | null
+  participants: Participant[] | null
+}
+
+export interface Participant {
+  user: User
+  isLeader: boolean
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,7 @@
+export interface User {
+  id: string
+  name: string
+  socialType: 'kakao' | 'google'
+  profileImage: string | null
+  email: string
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #16 

## 📝작업 내용

1. 엔빵 상세보기/수정하기 페이지 퍼블리싱을 완료했습니다.
> - 기존의 엔빵 생성하기/미리보기 페이지에서 사용한 컴포넌트를 재사용하기 위해 해당 컴포넌트(`NbreadCard`, `NbreadEditCard`, `NbreadParticipantCard`)를 일부 수정했습니다.
> - 참여자 목록을 `NbreadParticipantsList` 컴포넌트로 따로 분리하였으며, 더미데이터의 `participants`값을 참조해 엔빵 참여자 목록과 친구 초대 버튼을 렌더링하도록 구현했습니다.
> - `Checkbox` 컴포넌트를 구현하였으며, `Tab` 컴포넌트에 `size` props를 추가해 크기별로 사용할 수 있도록 수정했습니다.

2. type을 추가 및 수정했습니다.
> - @/type/nbread.ts 파일 내 `Nbread` type을 수정하였으며, `Participant` type을 추가했습니다.
> - @/type/user.ts 파일을 생성 및 `User` type을 추가했습니다.

4. 홈 페이지의 AddLogButton을 DashlineButton으로 수정했습니다.
> - 홈 페이지의 AddLogButton을 삭제하고 DashlineButton을 재사용하도록 변경했습니다.
> - AddLogButton 파일을 삭제 및 DashlineButton 컴포넌트명을 수정했습니다. (기존 DashlineCard에서 Button으로 변경)

5. 기타 수정사항을 반영했습니다.
> - detailHeader 내 뒤로가기 Icon에 `cursor-pointer` 속성을 추가했습니다.


### 스크린샷
![스크린샷 2025-02-21 오후 6 01 22](https://github.com/user-attachments/assets/5b45a69e-dfb7-4718-a6d4-9a6d9c940933)
![스크린샷 2025-02-21 오후 6 01 39](https://github.com/user-attachments/assets/d107ad80-0ea7-470f-beca-b0bdc24977af)


## 💬리뷰 요구사항(선택)
> 아직 더미데이터가 들어가 있는 상태라 수정한 후 저장해도 상세보기 페이지에는 반영되지 않습니다.
> 로그인 기능 PR 올라오고 나면 기능 구현하면서 수정할 예정입니다.
