### PR TITLE
[feature-13/feat] 마이 페이지 계정 정보 불러오기 기능 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,9 +8,8 @@ const nextConfig: NextConfig = {
     })
     return config
   },
-  // TODO 구글, 카카오 프로필 이미지 도메인 추가 필요
   images: {
-    domains: ['avatars.githubusercontent.com'], // TODO 프로필 이미지 테스트용 임시 도메인, 수정 필요
+    domains: ["k.kakaocdn.net", "lh3.googleusercontent.com"],
   },
 }
 

--- a/src/components/home/Header.tsx
+++ b/src/components/home/Header.tsx
@@ -14,7 +14,7 @@ const Header = () => {
         <button onClick={() => router.push("/calendar")} className="cursor-pointer mt-10">
           <Icon type="calendar" width={24} height={24} fill="text-gray-600" />
         </button>
-        <button onClick={() => router.push("/profile")} className="cursor-pointer mt-8 w-24 h-24">
+        <button onClick={() => router.push("/mypage")} className="cursor-pointer mt-8 w-24 h-24">
           <Avatar size="large" profileImageUrl={undefined} isNbreadLeader={false} />
         </button>
       </div>

--- a/src/components/mypage/MyInfo.tsx
+++ b/src/components/mypage/MyInfo.tsx
@@ -1,30 +1,26 @@
-"use client"
+"use client";
 
-import Avatar from '../../components/common/avatar/avatar';
+import Avatar from "../../components/common/avatar/avatar";
+import useUserStore from "@/stores/useAuthStore"; 
 
-interface MyInfoProps {
-  profileImageUrl: string; 
-}
+const MyInfo = () => {
+  const { user } = useUserStore(); 
 
-const MyInfo = ({ profileImageUrl }: MyInfoProps) => {
   return (
     <div className="card mt-12">
-      <div className="flex items-center justify-between mr-12">
-        <div>
-        <Avatar
-          profileImageUrl={profileImageUrl}
-          size="large"
-        />
-        </div>
-        <div className='flex-shrink-0 justify-between mr-225 ml-12'>
-          <p className="font-bold mb-5 text-heading05 text-gray-800">신혜민</p>
-          <p className="text-body04 text-gray-600 whitespace-nowrap">카카오 계정 
-            <span className="text-body04 text-gray-400 ml-12 mr-36 whitespace-nowrap"> asdf1234@naver.com</span>
-          </p> 
+      <div className="flex items-center justify-between px-6 py-4">
+        <Avatar profileImageUrl={user?.profileImage || "/default-avatar.png"} size="large" />
+
+        <div className="flex-shrink-0 justify-between mr-225 ml-12">
+          <p className="font-bold mb-5 text-heading05 text-gray-800">{user?.name || "이름 없음"}</p>
+          <p className="text-body04 text-gray-600 whitespace-nowrap">
+            {user?.socialType?.toUpperCase() || "소셜 로그인"} 계정
+            <span className="text-body04 text-gray-400 ml-12 mr-36 whitespace-nowrap">{user?.email || "이메일 없음"}</span>
+          </p>
         </div>
       </div>
     </div>
   );
-}
+};
 
 export default MyInfo;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #26 

## 📝작업 내용

> user-store에서 계정 정보 받아서 표시해주는 기능 구현

### 스크린샷
<img width="328" alt="image" src="https://github.com/user-attachments/assets/6ecd96bb-1e26-47a1-8994-288f44d7c56c" />

## 💬리뷰 요구사항(선택)

> kakao 프로필 이미지 받아올 시 크기가 줄어드는 버그가 있어 수정 필요 (추후에 수정)
