### PR TITLE
[feature-12/nbread-craete] 엔빵 생성하기 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.47.14",
-        "@types/js-cookie": "^3.0.6",
         "autoprefixer": "^10.4.20",
         "classnames": "^2.5.1",
-        "cookie": "^1.0.2",
-        "js-cookie": "^3.0.5",
         "next": "15.1.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
+        "react-toastify": "^11.0.5",
         "tailwindcss-preset-px-to-rem": "^1.2.1",
         "zustand": "^5.0.3"
       },
@@ -3134,12 +3132,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/js-cookie": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
-      "integrity": "sha512-wkw9yd1kEXOPnvEeEV1Go1MmxtBJL0RR79aOTAApecWFVu7w0NNXNqhcWgvw2YgZDYadliXkl14pa3WXw5jlCQ==",
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -4116,6 +4108,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -4184,15 +4185,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/core-js-compat": {
       "version": "3.40.0",
@@ -6390,15 +6382,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7562,6 +7545,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
+    "react-toastify": "^11.0.5",
     "tailwindcss-preset-px-to-rem": "^1.2.1",
     "zustand": "^5.0.3"
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import '../styles/globals.css'
+import Toast from '@/components/common/toast/Toast'
 
 export const metadata: Metadata = {
   title: 'Create Next App',
@@ -20,6 +21,7 @@ export default function RootLayout({
         />
       </head>
       <body className={`font-pre`} suppressHydrationWarning>
+        <Toast />
         {children}
       </body>
     </html>

--- a/src/app/nbread/create/page.tsx
+++ b/src/app/nbread/create/page.tsx
@@ -8,9 +8,11 @@ import { Nbread } from '@/types/nbread'
 import classNames from 'classnames'
 import { useEffect } from 'react'
 import useNbreadStore from '@/stores/useNbreadStore'
+import useUserStore from '@/stores/useAuthStore'
 
 const Page = () => {
   const router = useRouter()
+  const userData = useUserStore((state) => state.user)
   const { setNbread } = useNbreadStore()
   const nbreadFormData = useNbreadStore((state) => state.nbread)
   const {
@@ -23,6 +25,9 @@ const Page = () => {
   } = useForm<Nbread>({ mode: 'onChange' })
 
   const onSubmit = (data: Nbread) => {
+    data.leaderId = userData!.id
+    data.participants = [{ user: userData!, isLeader: true }]
+
     setNbread(data)
     router.push('/nbread/preview')
   }
@@ -36,7 +41,7 @@ const Page = () => {
   return (
     <main className="flex h-full flex-col justify-between p-24">
       <section>
-        <DetailHeader></DetailHeader>
+        <DetailHeader />
         <h3 className="pb-12 pt-20">엔빵 만들기 🍞</h3>
         <NbreadEditCard
           register={register}

--- a/src/app/nbread/preview/page.tsx
+++ b/src/app/nbread/preview/page.tsx
@@ -6,9 +6,34 @@ import NbreadCard from '@/components/nbread/nbreadCard'
 import NbreadParticipantCard from '@/components/nbread/nbreadParticipantCard'
 import useNbreadStore from '@/stores/useNbreadStore'
 import { Nbread } from '@/types/nbread'
+import { insertNbread } from '@/lib/nbread'
+import { insertParticipant } from '@/lib/participant'
+import { useToast } from '@/components/common/toast/Toast'
+import { useRouter } from 'next/navigation'
+import useUserStore from '@/stores/useAuthStore'
 
 const Page = () => {
   const nbreadData = useNbreadStore((state) => state.nbread)
+  const userData = useUserStore((state) => state.user)
+  const { clearNbread } = useNbreadStore()
+  const router = useRouter()
+
+  const handleClickSubmitButton = async () => {
+    if (nbreadData && nbreadData.participants) {
+      try {
+        const newNbreadId = await insertNbread(nbreadData!)
+        await insertParticipant(nbreadData.participants[0], newNbreadId)
+
+        clearNbread()
+        useToast.success('엔빵 만들기에 성공했어요.')
+        router.push('/home')
+      } catch (error) {
+        useToast.error('엔빵 만들기에 실패했어요. 다시 시도해주세요.')
+        console.error(error)
+        router.push('/nbread/create')
+      }
+    }
+  }
 
   return (
     <main className="h-full-y-auto relative p-24">
@@ -17,12 +42,16 @@ const Page = () => {
         <div className="pt-20 text-body03 text-gray-400">
           작성한 엔빵의 미리보기에요.
         </div>
-        <h2 className="pb-12 pt-4">{nbreadData?.title}</h2>
-        <NbreadCard nbreadData={nbreadData as Nbread} />
+        <h2 className="pb-12 pt-4">{nbreadData?.title || '저장 중...'}</h2>
+        {<NbreadCard nbreadData={nbreadData as Nbread} />}
         <div className="mb-12 mt-40 text-body02 text-gray-500">참여한 사람</div>
         <div className="mb-40 flex flex-col gap-8">
           {/* TODO 로그인 기능 구현 후 데이터 수정 필요 */}
-          <NbreadParticipantCard isNbreadLeader={true} name={'신혜민'} />
+          <NbreadParticipantCard
+            isNbreadLeader={true}
+            name={userData!.name}
+            profileImageUrl={userData!.profileImage}
+          />
           <DashlineCard
             text="친구는 엔빵을 만든 후 초대할 수 있어요."
             iconType="warning"
@@ -32,7 +61,7 @@ const Page = () => {
         </div>
         <button
           className="btn btn-large btn-primary mb-20"
-          onClick={() => null}
+          onClick={() => handleClickSubmitButton()}
         >
           엔빵 만들기 🍞
         </button>

--- a/src/components/common/avatar/avatar.tsx
+++ b/src/components/common/avatar/avatar.tsx
@@ -1,12 +1,12 @@
 import DefaultAvatar from '@/assets/avatar.svg'
 import Image from 'next/image'
-import Icon from '../icon/icon'
+import Icon from '../icon/Icon'
 
 const avatarSizeMap = { small: 24, large: 32 } as const
 
 interface AvatarProps {
   size: keyof typeof avatarSizeMap
-  profileImageUrl?: string
+  profileImageUrl?: string | null
   isNbreadLeader?: boolean
 }
 

--- a/src/components/common/toast/Toast.tsx
+++ b/src/components/common/toast/Toast.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { Slide, toast, ToastContainer } from 'react-toastify'
+
+const Toast = () => {
+  return (
+    <ToastContainer
+      position="bottom-center"
+      autoClose={2000}
+      hideProgressBar
+      closeOnClick={true}
+      closeButton={false}
+      limit={1}
+      transition={Slide}
+    />
+  )
+}
+
+export const useToast = {
+  success: (message: string) => {
+    toast.success(message)
+  },
+  error: (message: string) => {
+    toast.error(message)
+  },
+}
+
+export default Toast

--- a/src/components/nbread/nbreadCard.tsx
+++ b/src/components/nbread/nbreadCard.tsx
@@ -1,40 +1,50 @@
 import { Nbread } from '@/types/nbread'
 
 interface NbreadCardProps {
-  nbreadData: Nbread
+  nbreadData: Nbread | null
 }
 
 const NbreadCard = ({ nbreadData }: NbreadCardProps) => {
   return (
     <>
-      <div className="card px-24 pb-32">
-        <div className="pb-4 text-body03 text-gray-600">총 금액</div>
-        <div className="text-heading01 text-secondary-200">
-          {Number(nbreadData.amount).toLocaleString()}원
-        </div>
-        <hr className="mt-20 border-gray-100" />
-        <div className="flex flex-col gap-16 pt-20">
-          <div className="flex flex-row items-center justify-between">
-            <div className="w-120 text-body02 text-gray-500">참여 인원</div>
-            <div className="text-body02 text-gray-800">
-              {nbreadData.participantCount}명
+      <div className="card min-h-200 px-24 pb-32">
+        {nbreadData ? (
+          <>
+            <div className="pb-4 text-body03 text-gray-600">총 금액</div>
+            <div className="text-heading01 text-secondary-200">
+              {Number(nbreadData.amount).toLocaleString()}원
             </div>
-          </div>
-          <div className="flex flex-row items-center justify-between">
-            <div className="w-120 text-body02 text-gray-500">엔빵 금액</div>
-            <div className="text-body02 text-gray-800">
-              {nbreadData.paymentAmount.toLocaleString()}원
+            <hr className="mt-20 border-gray-100" />
+            <div className="flex flex-col gap-16 pt-20">
+              <div className="flex flex-row items-center justify-between">
+                <div className="w-120 text-body02 text-gray-500">참여 인원</div>
+                <div className="text-body02 text-gray-800">
+                  {nbreadData.participantCount}명
+                </div>
+              </div>
+              <div className="flex flex-row items-center justify-between">
+                <div className="w-120 text-body02 text-gray-500">엔빵 금액</div>
+                <div className="text-body02 text-gray-800">
+                  {nbreadData.paymentAmount.toLocaleString()}원
+                </div>
+              </div>
+              <div className="flex flex-row items-center justify-between">
+                <div className="w-120 text-body02 text-gray-500">
+                  정기 결제일
+                </div>
+                <div className="text-body02 text-gray-800">
+                  {nbreadData.paymentPeriod === 'year'
+                    ? `매년 ${nbreadData.paymentMonth}월 ${nbreadData.paymentDate}일`
+                    : `매월 ${nbreadData.paymentDate}일`}
+                </div>
+              </div>
             </div>
+          </>
+        ) : (
+          <div className="text-body02 text-gray-400">
+            엔빵 데이터 저장 중...
           </div>
-          <div className="flex flex-row items-center justify-between">
-            <div className="w-120 text-body02 text-gray-500">정기 결제일</div>
-            <div className="text-body02 text-gray-800">
-              {nbreadData.paymentPeriod === 'year'
-                ? `매년 ${nbreadData.paymentMonth}월 ${nbreadData.paymentDate}일`
-                : `매월 ${nbreadData.paymentDate}일`}
-            </div>
-          </div>
-        </div>
+        )}
       </div>
     </>
   )

--- a/src/components/nbread/nbreadParticipantCard.tsx
+++ b/src/components/nbread/nbreadParticipantCard.tsx
@@ -1,9 +1,9 @@
 import Avatar from '../common/avatar/avatar'
 import Checkbox from '../common/checkbox/checkbox'
-import Icon from '../common/icon/icon'
+import Icon from '../common/icon/Icon'
 
 interface NbreadParticipantCardProps {
-  profileImageUrl?: string
+  profileImageUrl?: string | null
   isNbreadLeader: boolean
   name: string
   paymentAmount?: number

--- a/src/lib/nbread/deleteNbread.ts
+++ b/src/lib/nbread/deleteNbread.ts
@@ -1,0 +1,19 @@
+import { supabase } from '@/lib/supabaseClient'
+
+export const insertNbread = async (nbreadId: string) => {
+  try {
+    const { data, error } = await supabase
+      .from('nbread')
+      .delete()
+      .eq('id', nbreadId)
+
+    if (error) {
+      console.error('Error inserting nbread:', error)
+      throw error
+    }
+
+    return data
+  } catch (error) {
+    throw error
+  }
+}

--- a/src/lib/nbread/deleteNbread.ts
+++ b/src/lib/nbread/deleteNbread.ts
@@ -1,6 +1,6 @@
 import { supabase } from '@/lib/supabaseClient'
 
-export const insertNbread = async (nbreadId: string) => {
+export const deleteNbread = async (nbreadId: string) => {
   try {
     const { data, error } = await supabase
       .from('nbread')

--- a/src/lib/nbread/index.ts
+++ b/src/lib/nbread/index.ts
@@ -1,0 +1,1 @@
+export { insertNbread } from './insertNbread'

--- a/src/lib/nbread/insertNbread.ts
+++ b/src/lib/nbread/insertNbread.ts
@@ -1,0 +1,29 @@
+import { supabase } from '@/lib/supabaseClient'
+import { Nbread } from '@/types/nbread'
+
+export const insertNbread = async (nbread: Nbread) => {
+  try {
+    const { data, error } = await supabase
+      .from('nbread')
+      .insert({
+        title: nbread.title,
+        participant_count: nbread.participantCount,
+        amount: nbread.amount,
+        payment_period: nbread.paymentPeriod,
+        payment_date: nbread.paymentDate,
+        payment_month: nbread.paymentMonth,
+        leader_id: nbread.leaderId,
+      })
+      .select('id')
+      .single()
+
+    if (error) {
+      console.error('Error inserting nbread:', error)
+      throw error
+    }
+
+    return data.id
+  } catch (error) {
+    throw error
+  }
+}

--- a/src/lib/participant/index.ts
+++ b/src/lib/participant/index.ts
@@ -1,0 +1,1 @@
+export { insertParticipant } from './insertParticipant'

--- a/src/lib/participant/insertParticipant.ts
+++ b/src/lib/participant/insertParticipant.ts
@@ -1,0 +1,20 @@
+import { supabase } from '@/lib/supabaseClient'
+import { Participant } from '@/types/nbread'
+
+export const insertParticipant = async (
+  participant: Participant,
+  nbreadId: string,
+) => {
+  const { data, error } = await supabase.from('participant').insert({
+    nbread_id: nbreadId,
+    user_id: participant.user.id,
+    is_leader: participant.isLeader,
+  })
+
+  if (error) {
+    console.error('Error inserting participant:', error)
+    return null
+  }
+
+  return data
+}

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,34 +1,34 @@
-'use client';  // 클라이언트 전용 코드
+'use client' // 클라이언트 전용 코드
 
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY as string;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY as string
 
 // 클라이언트 환경인지 확인 후 sessionStorage 사용
-const authConfig = typeof window !== 'undefined' ? {
-  auth: {
-    storage: sessionStorage, // 클라이언트에서만 사용
-    autoRefreshToken: true,
-    persistSession: true,
-    detectSessionInUrl: true,
-  },
-} : {};
+const authConfig =
+  typeof window !== 'undefined'
+    ? {
+        auth: {
+          storage: sessionStorage, // 클라이언트에서만 사용
+          autoRefreshToken: true,
+          persistSession: true,
+          detectSessionInUrl: true,
+        },
+      }
+    : {}
 
-export const supabase = createClient(supabaseUrl, supabaseKey, authConfig);
+export const supabase = createClient(supabaseUrl, supabaseKey, authConfig)
 
 // 클라이언트에서만 auth 상태 변화를 처리
 if (typeof window !== 'undefined') {
   supabase.auth.onAuthStateChange((event, session) => {
     if (event === 'SIGNED_IN' && session) {
       // 사용자가 로그인했을 때, sessionStorage에 토큰 저장
-      sessionStorage.setItem('access_token', session.access_token);
-      
-      
+      sessionStorage.setItem('access_token', session.access_token)
     } else if (event === 'SIGNED_OUT') {
       // 로그아웃시 토큰 삭제
-      sessionStorage.removeItem('access_token');
-      
+      sessionStorage.removeItem('access_token')
     }
-  });
+  })
 }

--- a/src/stores/useNbreadStore.tsx
+++ b/src/stores/useNbreadStore.tsx
@@ -3,12 +3,15 @@ import { create } from 'zustand'
 
 interface NbreadStore {
   nbread: Nbread | null
-  setNbread: (nbread: Nbread | null) => void
+  setNbread: (nbread: Nbread) => void
+  clearNbread: () => void
 }
 
+// TODO 초기값 null에서 객체로 직접 필드 초기값 지정, store 변수명 변경 필요(newNbread, createNbread 등..)
 const useNbreadStore = create<NbreadStore>()((set) => ({
   nbread: null,
   setNbread: (nbread) => set({ nbread: nbread }),
+  clearNbread: () => set({ nbread: null }),
 }))
 
 export default useNbreadStore

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -177,3 +177,29 @@ a {
     @apply bg-gray-200 text-gray-400;
   }
 }
+
+/* toast 스타일 커스텀 */
+.Toastify__toast-container {
+  @apply p-24;
+}
+
+.Toastify__toast {
+  @apply min-h-48 items-center rounded-4 px-20;
+}
+
+.Toastify__toast--success {
+  @apply bg-system-green font-pretendard text-heading05 text-white;
+}
+
+.Toastify__toast--error {
+  @apply bg-system-red font-pretendard text-heading05 text-white;
+}
+
+.Toastify__toast-icon {
+  @apply h-16 w-16;
+}
+
+.Toastify__toast-icon svg {
+  @apply h-16 w-16;
+  fill: white;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,10 +25,10 @@ export default {
           300: '#FF8204',
         },
         system: {
-          red: '#F74F3B',
-          blue: '#197AE3',
+          red: '#FE5E4B',
+          blue: '#55CBEF',
           yellow: '#FFEB00',
-          green: '#46F24B',
+          green: '#57E45C',
         },
         gray: {
           100: '#F5F5F5',


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23 

## 📝작업 내용

**1. 엔빵 생성하기 기능을 구현했습니다.**
> - 엔빵 미리보기 페이지에서 엔빵 만들기 버튼 클릭 시 데이터가 DB에 저장되도록 구현했습니다.
> - 데이터가 저장된 후, Toast 메시지를 출력하고 홈 화면으로 이동됩니다.
> - 엔빵 폼을 작성하지 않고 직접 URL을 입력해 미리보기 페이지로 이동한 경우, 작성하기 페이지로 이동되도록 예외처리를 구현했습니다.

**2. `/lib` 디렉토리 구조를 설정했습니다.**
> - supabase와의 통신 코드를 모아두는 `/lib` 디렉토리 구조를 설정했습니다.
> - 통신 코드 작성 시 디렉토리 구조와 컨벤션에 맞게 작성해주시면 됩니다.
> - 디렉토리 구조 및 컨벤션은 #23 이슈에 자세히 적어두었으니 확인 부탁드립니다.

**3. Toast 컴포넌트를 구현했습니다.**
> - react-toastify 라이브러리를 활용해 Toast 컴포넌트를 구현 및 스타일을 커스터마이징했습니다.
> - `success`, `error` 두 가지 타입을 가지고 있습니다.
> - useToast 메소드를 사용해 UI 어디에서나 활용할 수 있습니다.

### 스크린샷
![스크린샷 2025-02-25 오후 6 03 20](https://github.com/user-attachments/assets/5da2ab48-ba40-4a9f-b118-99e77906ac67)
![스크린샷 2025-02-25 오후 6 04 01](https://github.com/user-attachments/assets/d7245fa1-aef5-43a6-a3ac-29537a8495c8)
> Toast 메시지 출력 예시

![스크린샷 2025-02-25 오후 6 04 33](https://github.com/user-attachments/assets/72d5c357-ac6b-436a-9646-aae6d8137762)
![스크린샷 2025-02-25 오후 6 05 25](https://github.com/user-attachments/assets/d8672c6a-071e-4e9c-8941-583ea0c68f0a)
> Nbread, Participant 테이블에 데이터 저장 성공

<br>

## 💬리뷰 요구사항

> /lib 디렉토리에 메소드 작성 시 #23  에 작성되어 있는 디렉토리 구조 및 컨벤션 참고 부탁드립니다.
