### PR TITLE
[feature-20/nbread-record-update] 엔빵 납부 여부 업데이트 기능 구현 완료

### DIFF
--- a/src/app/nbread/[nbreadId]/page.tsx
+++ b/src/app/nbread/[nbreadId]/page.tsx
@@ -122,6 +122,8 @@ const Page = () => {
               <NbreadCard nbreadData={nbread as Nbread} />
             )}
             <NbreadParticipantsList
+              nbreadId={nbread.id}
+              currentPaymentDate={nbread.currentPaymentDate!}
               participants={nbread.participants!}
               participantMaxCount={nbread.participantCount}
               leaderId={nbread.leaderId!}

--- a/src/app/nbread/[nbreadId]/page.tsx
+++ b/src/app/nbread/[nbreadId]/page.tsx
@@ -130,12 +130,14 @@ const Page = () => {
             />
           </>
         )}
-        <button
-          className="btn btn-large btn-warning"
-          onClick={() => setIsNbreadDeleteModalOpen(true)}
-        >
-          엔빵 삭제하기
-        </button>
+        {isEditing && (
+          <button
+            className="btn btn-large btn-warning"
+            onClick={() => setIsNbreadDeleteModalOpen(true)}
+          >
+            엔빵 삭제하기
+          </button>
+        )}
         <NbreadDeleteModal
           isOpen={isNbreadDeleteModalOpen}
           onClose={() => setIsNbreadDeleteModalOpen(false)}

--- a/src/app/nbread/[nbreadId]/page.tsx
+++ b/src/app/nbread/[nbreadId]/page.tsx
@@ -143,7 +143,6 @@ const Page = () => {
           onClose={() => setIsNbreadDeleteModalOpen(false)}
           onSubmit={() => handleDeleteNbread(nbread!.id)}
         />
-        <></>
       </section>
     </main>
   )

--- a/src/components/common/checkbox/checkbox.tsx
+++ b/src/components/common/checkbox/checkbox.tsx
@@ -1,13 +1,18 @@
 interface CheckboxProps {
   disabled?: boolean
   isChecked?: boolean
-  onClick: () => void
+  onChange: () => void
 }
 
-const Checkbox = ({ disabled, isChecked, onClick }: CheckboxProps) => {
+const Checkbox = ({ disabled, isChecked, onChange }: CheckboxProps) => {
   return (
-    <label className="checkbox_label h-16" onClick={onClick}>
-      <input type="checkbox" disabled={disabled || false} checked={isChecked} />
+    <label className="checkbox_label h-16">
+      <input
+        type="checkbox"
+        disabled={disabled || false}
+        onChange={onChange}
+        checked={isChecked}
+      />
       <span className="checkbox_icon" />
     </label>
   )

--- a/src/components/nbread/nbreadParticipantCard.tsx
+++ b/src/components/nbread/nbreadParticipantCard.tsx
@@ -1,8 +1,14 @@
+import { updateNbreadRecord } from '@/lib/nbreadRecord'
 import Avatar from '../common/avatar/avatar'
 import Checkbox from '../common/checkbox/checkbox'
 import Icon from '../common/icon/Icon'
+import { useToast } from '../common/toast/Toast'
+import useUserStore from '@/stores/useAuthStore'
+import { useState } from 'react'
 
 interface NbreadParticipantCardProps {
+  nbreadId: string
+  currentPaymentDate: string
   profileImageUrl?: string | null
   isNbreadLeader: boolean
   name: string
@@ -10,12 +16,31 @@ interface NbreadParticipantCardProps {
   hasCheckbox?: boolean
   isChecked?: boolean
   isCheckboxDisabled?: boolean
-  onClickCheckbox?: () => void
+  // onClickCheckbox?: () => void
   hasDelete?: boolean
   onClickDelete?: () => void
 }
 
 const NbreadParticipantCard = (props: NbreadParticipantCardProps) => {
+  const [isChecked, setIsChecked] = useState<boolean>(props.isChecked || false)
+  const userData = useUserStore((state) => state.user)
+
+  const handleClickCheckbox = async () => {
+    try {
+      const data = await updateNbreadRecord(
+        props.nbreadId,
+        userData!.id,
+        !isChecked,
+        props.currentPaymentDate,
+      )
+
+      useToast.success('완료 여부 업데이트에 성공했어요.')
+      setIsChecked(!isChecked)
+    } catch (error) {
+      useToast.error('완료 여부 업데이트에 실패했어요. 다시 시도해주세요.')
+    }
+  }
+
   return (
     <div className="card flex flex-row items-center justify-between">
       <div className="align-center flex flex-row items-center gap-16">
@@ -34,8 +59,8 @@ const NbreadParticipantCard = (props: NbreadParticipantCardProps) => {
       {props.hasCheckbox && (
         <Checkbox
           disabled={props.isCheckboxDisabled}
-          isChecked={props.isChecked}
-          onClick={() => props.onClickCheckbox && props.onClickCheckbox()}
+          isChecked={isChecked}
+          onChange={() => handleClickCheckbox()}
         />
       )}
       {props.hasDelete && (

--- a/src/components/nbread/nbreadParticipantsList.tsx
+++ b/src/components/nbread/nbreadParticipantsList.tsx
@@ -2,8 +2,12 @@ import { Participant } from '@/types/nbread'
 import NbreadParticipantCard from './nbreadParticipantCard'
 import DashlineCard from '../common/card/dashlineCard'
 import useUserStore from '@/stores/useAuthStore'
+import { updateNbreadRecord } from '@/lib/nbreadRecord'
+import { useToast } from '../common/toast/Toast'
 
 interface NbreadParticipantsListProps {
+  nbreadId: string
+  currentPaymentDate: string
   participants: Participant[]
   participantMaxCount: number
   paymentAmount: number
@@ -12,6 +16,8 @@ interface NbreadParticipantsListProps {
 }
 
 const NbreadParticipantsList = ({
+  nbreadId,
+  currentPaymentDate,
   participants,
   participantMaxCount,
   paymentAmount,
@@ -29,6 +35,8 @@ const NbreadParticipantsList = ({
             {participants.map((participant, index) => (
               <NbreadParticipantCard
                 key={index}
+                nbreadId={nbreadId}
+                currentPaymentDate={currentPaymentDate}
                 isNbreadLeader={true}
                 name={participant.user.name}
                 paymentAmount={paymentAmount}
@@ -38,6 +46,7 @@ const NbreadParticipantsList = ({
                   participant.user.id !== userData?.id
                 }
                 hasDelete={isEditing && participant.user.id !== userData?.id}
+                // onClickCheckbox={() => console.log('엔빵 납부 여부 업데이트')}
                 // TODO 친구초대 기능 구현 후 모달 구현
                 onClickDelete={() => console.log('엔빵 멤버 삭제 모달 오픈')}
               />
@@ -53,7 +62,9 @@ const NbreadParticipantsList = ({
           Array.from({ length: participantMaxCount }).map((_, index) =>
             participants && index < participants.length ? (
               <NbreadParticipantCard
+                nbreadId={nbreadId}
                 key={index}
+                currentPaymentDate={currentPaymentDate}
                 isNbreadLeader={true}
                 name={participants[index].user.name}
                 paymentAmount={paymentAmount}

--- a/src/lib/nbread/getNbread.ts
+++ b/src/lib/nbread/getNbread.ts
@@ -28,6 +28,7 @@ export const getNbread = async (nbreadId: string) => {
       paymentPeriod: data.payment_period as 'year' | 'month',
       leaderId: data.leader_id,
       participants: null,
+      currentPaymentDate: data.current_payment_date,
     }
 
     return nbread

--- a/src/lib/nbread/getUserNbread.ts
+++ b/src/lib/nbread/getUserNbread.ts
@@ -48,6 +48,7 @@ export const getUserNbreads = async (userId: string): Promise<Nbread[]> => {
       paymentPeriod: nbread.payment_period as 'year' | 'month',
       leaderId: nbread.leader_id,
       participants: null,
+      currentPaymentDate: nbread.current_payment_date,
     }),
   )
 

--- a/src/lib/nbreadRecord/index.ts
+++ b/src/lib/nbreadRecord/index.ts
@@ -1,0 +1,1 @@
+export { updateNbreadRecord } from './updateNbreadRecord'

--- a/src/lib/nbreadRecord/updateNbreadRecord.ts
+++ b/src/lib/nbreadRecord/updateNbreadRecord.ts
@@ -1,0 +1,34 @@
+import { supabase } from '@/lib/supabaseClient'
+import { Nbread } from '@/types/nbread'
+
+export const updateNbreadRecord = async (
+  nbreadId: string,
+  userId: string,
+  isPaid: boolean,
+  currentPaymentDate: string,
+) => {
+  const translatedCurrentPaymentDate = new Date(currentPaymentDate)
+    .toISOString()
+    .split('T')[0]
+
+  try {
+    const { data, error } = await supabase
+      .from('nbread_records')
+      .update({
+        is_paid: isPaid,
+      })
+      .eq('nbread_id', nbreadId)
+      .eq('user_id', userId)
+      .eq('payment_date', translatedCurrentPaymentDate) // payment-date가 currentPaymentDate와 동일한 row만 업데이트(가장 최신 row만 업데이트)
+
+    if (error) {
+      console.error('Error updating nbread record:', error)
+      throw error
+    }
+
+    return data
+  } catch (error) {
+    console.error('Error updating nbread record:', error)
+    throw error
+  }
+}

--- a/src/types/nbread.ts
+++ b/src/types/nbread.ts
@@ -10,6 +10,7 @@ export interface Nbread {
   paymentDate: number | null
   leaderId: string | null
   participants: Participant[] | null
+  currentPaymentDate: string | null
 }
 
 export interface Participant {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #43 

## 📝작업 내용

**1. 엔빵 납부 여부 업데이트 기능을 구현했습니다.**
> - 이번 달 엔빵 납부 여부를 업데이트하는 `updateNbreadRecord`를 구현했습니다.
> - `NbreadParticipantCard` 내의 체크박스 클릭 시 체크 여부에 따라 엔빵 납부 여부를 업데이트하도록 구현했습니다.
> -  납부 성공/실패 시 useToast로 각각 success, error 메시지를 노출하도록 구현했습니다.

**2. 기타 수정사항을 반영했습니다.**
> - 엔빵 삭제하기 버튼이 엔빵 수정 상태에서만 노출되도록 수정했습니다.

### 스크린샷
![스크린샷 2025-02-28 오후 8 10 43](https://github.com/user-attachments/assets/b1e60c40-2ba6-4732-8690-9fbe0f2b3fb7)
![스크린샷 2025-02-28 오후 8 11 45](https://github.com/user-attachments/assets/cfc7c514-fc3a-4db5-b0e4-9a19cdeb03f4)
> is_paid 필드의 False값이 True로 변경됨
> (반대의 경우`(True -> False)`도 정상적으로 업데이트됩니다)

## 💬리뷰 요구사항

> 해당 내용 pull 받으시면 홈페이지에서 납부 완료 인원 계산 및 테스트 가능합니다.
