### PR TITLE
[feature-22/get-nbread-record] 엔빵 납부 여부 불러오기 기능 구현

### DIFF
--- a/src/app/nbread/[nbreadId]/page.tsx
+++ b/src/app/nbread/[nbreadId]/page.tsx
@@ -8,15 +8,19 @@ import NbreadEditCard from '@/components/nbread/nbreadEditCard'
 import NbreadParticipantsList from '@/components/nbread/nbreadParticipantsList'
 import { deleteNbread, getNbread, updateNbread } from '@/lib/nbread'
 import { getParticipants } from '@/lib/participant'
-import { Nbread } from '@/types/nbread'
+import { Nbread, NbreadRecord } from '@/types/nbread'
 import { useRouter, useParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import NbreadDeleteModal from '@/components/common/Modal/NbreadDeleteModal'
 import NbreadInviteModal from '@/components/common/Modal/NbreadInviteModal'
+import { getNbreadRecords } from '@/lib/nbreadRecord'
 
 const Page = () => {
   const [nbread, setNbread] = useState<Nbread | null>(null)
+  const [nbreadRecords, setNbreadRecords] = useState<NbreadRecord[] | null>(
+    null,
+  )
   const [isNbreadDeleteModalOpen, setIsNbreadDeleteModalOpen] =
     useState<boolean>(false)
   const [isNbreadInviteModalOpen, setIsNbreadInviteModalOpen] =
@@ -95,10 +99,23 @@ const Page = () => {
   }, [])
 
   useEffect(() => {
+    const fetchNbreadRecordData = async () => {
+      const nbreadRecordsData = await getNbreadRecords(
+        nbread!.id,
+        nbread!.currentPaymentDate!,
+      )
+      setNbreadRecords(nbreadRecordsData)
+    }
+
     if (nbread) {
       reset(nbread)
+      fetchNbreadRecordData()
     }
   }, [nbread])
+
+  useEffect(() => {
+    if (nbreadRecords) console.log(nbreadRecords)
+  }, [nbreadRecords])
 
   return (
     <main className="h-full-y-auto relative p-24">
@@ -129,16 +146,19 @@ const Page = () => {
             ) : (
               <NbreadCard nbreadData={nbread as Nbread} />
             )}
-            <NbreadParticipantsList
-              nbreadId={nbread.id}
-              currentPaymentDate={nbread.currentPaymentDate!}
-              participants={nbread.participants!}
-              participantMaxCount={nbread.participantCount}
-              leaderId={nbread.leaderId!}
-              isEditing={isEditing}
-              paymentAmount={nbread.paymentAmount!}
-              onClick={() => handleClickInviteCard()}
-            />
+            {nbreadRecords && (
+              <NbreadParticipantsList
+                nbreadId={nbread.id}
+                nbreadRecords={nbreadRecords!}
+                currentPaymentDate={nbread.currentPaymentDate!}
+                participants={nbread.participants!}
+                participantMaxCount={nbread.participantCount}
+                leaderId={nbread.leaderId!}
+                isEditing={isEditing}
+                paymentAmount={nbread.paymentAmount!}
+                onClick={() => handleClickInviteCard()}
+              />
+            )}
           </>
         )}
         {isEditing && (

--- a/src/app/nbread/[nbreadId]/page.tsx
+++ b/src/app/nbread/[nbreadId]/page.tsx
@@ -113,10 +113,6 @@ const Page = () => {
     }
   }, [nbread])
 
-  useEffect(() => {
-    if (nbreadRecords) console.log(nbreadRecords)
-  }, [nbreadRecords])
-
   return (
     <main className="h-full-y-auto relative p-24">
       <section>

--- a/src/components/home/MyNbreadList.tsx
+++ b/src/components/home/MyNbreadList.tsx
@@ -33,7 +33,7 @@ const MyNbreadList = ({ nbreadList }: MyNbreadListProps) => {
           </div>
           <div className="mr-12 flex min-h-[30px] flex-col justify-end">
             <p className="mt-auto text-body03 text-secondary-200">
-              {nbread.participantCount}명 참여 중
+              {nbread.participants?.length}명 참여 중
             </p>
           </div>
         </div>

--- a/src/components/home/NbreadCard.tsx
+++ b/src/components/home/NbreadCard.tsx
@@ -4,10 +4,10 @@ import { useRouter } from 'next/navigation'
 
 interface NbreadCardProps {
   nbread: Nbread
-  showParticipants?: boolean 
+  showParticipants?: boolean
 }
 
-const NbreadCard = ({ nbread, showParticipants = true }: NbreadCardProps) => {  
+const NbreadCard = ({ nbread, showParticipants = true }: NbreadCardProps) => {
   const router = useRouter()
   const participants = nbread.participants
 
@@ -42,11 +42,11 @@ const NbreadCard = ({ nbread, showParticipants = true }: NbreadCardProps) => {
         </div>
 
         {showParticipants && (
-            <p className="text-body04 text-secondary-300">
-            {nbread.paidCount === nbread.participantCount
-            ? `완료 ${nbread.paidCount} / ${nbread.participantCount}`
-            : `미완료 ${nbread.paidCount} / ${nbread.participantCount}`}
-            </p>
+          <p className="text-body04 text-secondary-300">
+            {nbread.paidCount === participants?.length
+              ? `완료 ${nbread.paidCount} / ${participants?.length}`
+              : `미완료 ${nbread.paidCount} / ${participants?.length}`}
+          </p>
         )}
       </div>
     </div>

--- a/src/components/nbread/nbreadParticipantCard.tsx
+++ b/src/components/nbread/nbreadParticipantCard.tsx
@@ -4,7 +4,7 @@ import Checkbox from '../common/checkbox/checkbox'
 import Icon from '../common/icon/Icon'
 import { useToast } from '../common/toast/Toast'
 import useUserStore from '@/stores/useAuthStore'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 
 interface NbreadParticipantCardProps {
   nbreadId: string
@@ -16,7 +16,6 @@ interface NbreadParticipantCardProps {
   hasCheckbox?: boolean
   isChecked?: boolean
   isCheckboxDisabled?: boolean
-  // onClickCheckbox?: () => void
   hasDelete?: boolean
   onClickDelete?: () => void
 }
@@ -24,10 +23,14 @@ interface NbreadParticipantCardProps {
 const NbreadParticipantCard = (props: NbreadParticipantCardProps) => {
   const [isChecked, setIsChecked] = useState<boolean>(props.isChecked || false)
   const userData = useUserStore((state) => state.user)
+  const isThrottling = useRef(false)
 
   const handleClickCheckbox = async () => {
+    if (isThrottling.current) return
+    isThrottling.current = true // ✅ 실행 중 상태 설정
+
     try {
-      const data = await updateNbreadRecord(
+      await updateNbreadRecord(
         props.nbreadId,
         userData!.id,
         !isChecked,
@@ -35,10 +38,14 @@ const NbreadParticipantCard = (props: NbreadParticipantCardProps) => {
       )
 
       useToast.success('완료 여부 업데이트에 성공했어요.')
-      setIsChecked(!isChecked)
+      setIsChecked((prev) => !prev)
     } catch (error) {
       useToast.error('완료 여부 업데이트에 실패했어요. 다시 시도해주세요.')
     }
+
+    setTimeout(() => {
+      isThrottling.current = false // ✅ 3초 후 다시 실행 가능하도록 초기화
+    }, 3000)
   }
 
   return (

--- a/src/components/nbread/nbreadParticipantsList.tsx
+++ b/src/components/nbread/nbreadParticipantsList.tsx
@@ -1,4 +1,4 @@
-import { Participant } from '@/types/nbread'
+import { NbreadRecord, Participant } from '@/types/nbread'
 import NbreadParticipantCard from './nbreadParticipantCard'
 import DashlineCard from '../common/card/dashlineCard'
 import useUserStore from '@/stores/useAuthStore'
@@ -7,6 +7,7 @@ import { useToast } from '../common/toast/Toast'
 
 interface NbreadParticipantsListProps {
   nbreadId: string
+  nbreadRecords: NbreadRecord[]
   currentPaymentDate: string
   participants: Participant[]
   participantMaxCount: number
@@ -19,6 +20,7 @@ interface NbreadParticipantsListProps {
 const NbreadParticipantsList = ({
   nbreadId,
   currentPaymentDate,
+  nbreadRecords,
   participants,
   participantMaxCount,
   paymentAmount,
@@ -28,20 +30,29 @@ const NbreadParticipantsList = ({
 }: NbreadParticipantsListProps) => {
   const userData = useUserStore((state) => state.user)
 
+  const participantsWithNbreadRecord = participants.map((participant) => {
+    const record = nbreadRecords.find(
+      (record) => record.userId === participant.user.id,
+    )
+    return { ...participant, isPaid: record ? record.isPaid : null }
+  })
+
   return (
     <section>
       <div className="mb-12 mt-40 text-body02 text-gray-500">참여한 사람</div>
       <div className="mb-40 flex flex-col gap-8">
         {isEditing ? (
           <>
-            {participants.map((participant, index) => (
+            {participantsWithNbreadRecord.map((participant, index) => (
               <NbreadParticipantCard
                 key={index}
                 nbreadId={nbreadId}
                 currentPaymentDate={currentPaymentDate}
-                isNbreadLeader={true}
+                isNbreadLeader={participant.isLeader}
                 name={participant.user.name}
+                profileImageUrl={participant.user.profileImage}
                 paymentAmount={paymentAmount}
+                isChecked={participant.isPaid!}
                 hasCheckbox={!isEditing}
                 isCheckboxDisabled={
                   leaderId !== userData!.id &&
@@ -61,15 +72,18 @@ const NbreadParticipantsList = ({
           </>
         ) : (
           Array.from({ length: participantMaxCount }).map((_, index) =>
-            participants && index < participants.length ? (
+            participantsWithNbreadRecord &&
+            index < participantsWithNbreadRecord.length ? (
               <NbreadParticipantCard
-                nbreadId={nbreadId}
                 key={index}
+                nbreadId={nbreadId}
                 currentPaymentDate={currentPaymentDate}
-                isNbreadLeader={true}
+                isNbreadLeader={participants[index].isLeader}
                 name={participants[index].user.name}
+                profileImageUrl={participants[index].user.profileImage}
                 paymentAmount={paymentAmount}
                 hasCheckbox={!isEditing}
+                isChecked={participantsWithNbreadRecord[index].isPaid!}
                 isCheckboxDisabled={
                   leaderId !== userData!.id &&
                   participants[index].user.id !== userData?.id

--- a/src/lib/nbreadRecord/getNbreadRecords.ts
+++ b/src/lib/nbreadRecord/getNbreadRecords.ts
@@ -1,0 +1,36 @@
+import { supabase } from '@/lib/supabaseClient'
+import { Nbread, NbreadRecord } from '@/types/nbread'
+
+export const getNbreadRecords = async (
+  nbreadId: string,
+  currentPaymentDate: string,
+) => {
+  const translatedCurrentPaymentDate = new Date(currentPaymentDate)
+    .toISOString()
+    .split('T')[0]
+
+  try {
+    const { data, error } = await supabase
+      .from('nbread_records')
+      .select('*')
+      .eq('nbread_id', nbreadId)
+      .eq('payment_date', translatedCurrentPaymentDate) // payment-date가 currentPaymentDate와 동일한 row만 불러오기
+
+    if (error) {
+      console.error('Error fetching nbread record:', error)
+      throw error
+    }
+
+    const renamedNbreadData: NbreadRecord[] = data.map((item) => ({
+      userId: item.user_id,
+      nbreadId: item.nbread_id,
+      paymentDate: item.payment_date,
+      isPaid: item.is_paid,
+    }))
+
+    return renamedNbreadData
+  } catch (error) {
+    console.error('Error fetching nbread record:', error)
+    throw error
+  }
+}

--- a/src/lib/nbreadRecord/index.ts
+++ b/src/lib/nbreadRecord/index.ts
@@ -1,1 +1,2 @@
+export { getNbreadRecords } from './getNbreadRecords'
 export { updateNbreadRecord } from './updateNbreadRecord'

--- a/src/types/nbread.ts
+++ b/src/types/nbread.ts
@@ -17,3 +17,10 @@ export interface Participant {
   user: User
   isLeader: boolean
 }
+
+export interface NbreadRecord {
+  userId: string
+  nbreadId: string
+  paymentDate: string
+  isPaid: boolean
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #48 

## 📝작업 내용

**1. 엔빵 납부 여부 불러오기 기능을 구현했습니다.**
> - 엔빵 납부 여부를 DB로부터 가져오는 `getNbreadRecords` 메서드를 구현했습니다.
> - 엔빵 상세 페이지의 체크박스에 DB에서 불러온 엔빵 납부 여부가 반영되도록 구현했습니다.

**2. 엔빵 납부 여부 업데이트에 throttling을 적용했습니다.**
> - 엔빵 납부 여부 업데이트 메서드를 과도하게 호출하지 않도록 3초 throttling을 적용했습니다.
> - `useRef`를 사용해 throttling이 적용되는 3초간은 메서드가 호출되지 않도록 구현했습니다.

**3. 홈페이지 엔빵 참여자 수를 엔빵 참여 가능 최대 인원이 아닌 실제 참여 중인 인원 수로 변경했습니다.**
> 기존에는 엔빵에 1명만 참여했더라도, 최대 참여 인원이 4명이면 `4명 참여 중` 이라고 표기되었습니다.
> 엔빵의 최대 참여 인원과 상관 없이 실제로 참여 중인 인원 수가 표기되도록 변경했습니다.

**4. 사용자 프로필 사진이 적용되지 않던 문제를 수정했습니다.** 

### 스크린샷
<img width="370" alt="스크린샷 2025-03-02 오후 6 41 43" src="https://github.com/user-attachments/assets/bb9b4b37-bb7c-45d9-9cc2-993275c248ca" />

> `1명 참여 중`으로 변경된 화면

## 💬리뷰 요구사항

> 참여 인원 수랑 체크박스 잘 반영되는지 확인 한번씩 부탁드립니다!