### PR TITLE
[hotfix-v1.0/css-scroll] 페이지 내 중복 스크롤 오류 해결 및 스크롤바 숨김 처리

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import NbreadText from '@/assets/logo/nbread-text.svg'
 
 const LoginPage = () => {
   return (
-    <div className="flex h-full w-full flex-col items-center justify-around">
+    <div className="flex h-svh w-full flex-col items-center justify-around">
       <div className="w-100% mt-80 flex flex-col items-center gap-16">
         <NbreadsImage />
         <NbreadText />

--- a/src/app/nbread/[nbreadId]/page.tsx
+++ b/src/app/nbread/[nbreadId]/page.tsx
@@ -141,7 +141,7 @@ const Page = () => {
   }
 
   return (
-    <main className="h-full-y-auto relative p-24">
+    <main className="h-full p-24">
       <section>
         <DetailHeader />
         {nbread && (

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -7,14 +7,16 @@ html {
   @apply overflow-y-hidden;
 }
 
-html,
 body {
-  @apply mx-auto max-h-svh min-h-dvh min-w-[320px] max-w-[600px] overflow-hidden bg-white shadow-[0_7px_29px_0_rgba(100,100,111,0.1)];
+  @apply mx-auto max-h-svh min-h-dvh min-w-[320px] max-w-[600px] overflow-y-auto bg-background font-pretendard text-gray-800 antialiased shadow-[0_7px_29px_0_rgba(100,100,111,0.1)];
   /* @apply mx-auto h-[100svh] min-h-screen min-w-[320px] max-w-[600px] overflow-x-hidden bg-white shadow-[0_7px_29px_0_rgba(100,100,111,0.1)]; */
 }
-
 body {
-  @apply max-h-svh min-h-dvh overflow-hidden overscroll-contain bg-background font-pretendard text-gray-800 antialiased;
+  -ms-overflow-style: none;
+}
+
+::-webkit-scrollbar {
+  display: none;
 }
 
 /* 기본 태그 스타일 초기화 및 커스터마이징 */


### PR DESCRIPTION
## #️⃣연관된 이슈

> #73 

## 📝작업 내용

**1. html, body의 height 및 overflow 속성을 수정해 중복 스크롤 오류를 해결했습니다.**
> - html에는 overflow-hidden을 적용해 스크롤이 중첩되지 않도록 수정했습니다.
> - body에는 min-height를 100dvh로 적용해, iOS에서도 viewport의 높이를 제대로 반영할 수 있도록 수정했습니다.
> - html 및 body에 중복으로 들어가 있던 CSS 속성을 분리했습니다.

**2. 스크롤바를 숨김 처리해 디바이스 간 스크롤바 노출 여부를 통일했습니다.**
> - 스크롤바를 모든 브라우저에서 숨김 처리해 디바이스 간 스크롤바 노출 여부에 차이가 나지 않도록 통일했습니다.

**3. 로그인 페이지 레이아웃 깨짐 현상을 수정했습니다.** 
> - 로그인 페이지 최상단 div의 높이를 svh로 수정해 레이아웃 꺠짐 현상을 해결했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
