### PR TITLE
[release-v1.1] 구글 애널리틱스 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import '../styles/globals.css'
 import ProtectRoute from './protectRoute'
 import Toast from '@/components/common/toast/Toast'
+import GoogleAnalytics from '@/lib/GoogleAnalytics'
 
 export const metadata: Metadata = {
   title: '엔빵',
@@ -24,6 +25,9 @@ export default function RootLayout({
       </head>
       <body className={`font-pre`} suppressHydrationWarning>
         <Toast />
+        {process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS && (
+          <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS} />
+        )}
         <ProtectRoute>{children}</ProtectRoute>
       </body>
     </html>

--- a/src/lib/GoogleAnalytics.tsx
+++ b/src/lib/GoogleAnalytics.tsx
@@ -1,0 +1,27 @@
+import Script from "next/script";
+ 
+const GoogleAnalytics = ({ gaId }: { gaId: string }) => {
+  return (
+    <>
+      <Script
+        async
+        src={`https://www.googletagmanager.com/gtag/js
+				?id=${gaId}`}
+      />
+      <Script
+        id="google-analytics"
+        dangerouslySetInnerHTML={{
+          __html: `
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+ 
+		gtag('config', '${gaId}');
+		`,
+        }}
+      />
+    </>
+  );
+};
+ 
+export default GoogleAnalytics;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #78 

## 📝작업 내용

> 구글애널리틱스 추가했습니다. 

### 스크린샷 (선택)

로컬에서 적용되는 거 확인했습니다.!

<img width="500" alt="스크린샷 2025-03-11 오후 12 30 43" src="https://github.com/user-attachments/assets/23fff968-6e77-4ebc-b466-80c5e96b9f43" />


## 💬리뷰 요구사항(선택)

- [이 블로그 정리가 너무 잘 되어 있어서 공유드려요..! ](https://velog.io/@newjin46/Next.js-13.4-Google-Analytics%EB%A5%BC-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8%EC%97%90-%EC%B6%94%EA%B0%80%ED%95%98%EA%B3%A0-%EC%82%AC%EC%9A%A9%EC%9E%90-%ED%8C%A8%ED%84%B4-%EB%B6%84%EC%84%9D%ED%95%98%EA%B8%B0)