### PR TITLE
[feature-33/nbread-chat] 그룹 채팅 기능 구현

### DIFF
--- a/src/app/nbread/[nbreadId]/chat/page.tsx
+++ b/src/app/nbread/[nbreadId]/chat/page.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import Avatar from '@/components/common/avatar/avatar'
+import { useToast } from '@/components/common/toast/Toast'
+import { getChatMessages } from '@/lib/chatMessage/getChatMessages'
+import { useRouter, useParams } from 'next/navigation'
+import { ChatMessage } from '@/types/chatMessage'
+import { useEffect, useState } from 'react'
+import useUserStore from '@/stores/useAuthStore'
+import { insertChatMessage } from '@/lib/chatMessage/insertChatMessage'
+import { supabase } from '@/lib/supabaseClient'
+
+const Page = () => {
+  const params = useParams()
+  const router = useRouter()
+  const user = useUserStore((state) => state.user)
+
+  const [nbreadId, setNbreadId] = useState<string>('')
+  const [inputText, setInputText] = useState<string>('')
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([])
+  const [hasFetched, setHasFetched] = useState<boolean>(false)
+
+  // DB로부터 해당 엔빵의 메시지 내역을 불러옴
+  const fetchChatMessages = async (nbreadId: string) => {
+    const data = await getChatMessages(nbreadId)
+    setChatMessages(data)
+    setHasFetched(true)
+  }
+
+  // 채팅방에 새로운 메시지를 전송
+  const sendChatMessages = async (content: string) => {
+    if (!params.nbreadId) {
+      useToast.error('잘못된 URL 주소입니다. 다시 시도해주세요.')
+      router.back()
+      return
+    }
+    const nbreadId = params.nbreadId as string
+    await insertChatMessage(user!, nbreadId, content)
+  }
+
+  // 해당 엔빵의 채팅방을 구독
+  const subscribeChatRoom = async () => {
+    // 1. 채널 생성 및 구독
+    const channel = supabase
+      .channel(`${nbreadId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'chat_messages',
+          filter: `nbread_id=eq.${nbreadId}`,
+        },
+        (payload) => {
+          // 2. 새로운 메시지 도착 시 state 업데이트
+          const newChatMessage: ChatMessage = {
+            id: payload.new.id,
+            content: payload.new.content,
+            userId: payload.new.user_id,
+            userName: payload.new.user_name,
+            userProfileImage: payload.new.user_profile_image,
+            nbreadId: payload.new.nbread_id,
+            createdAt: payload.new.created_at,
+          }
+          setChatMessages((prev) => [...prev, newChatMessage])
+          console.log('payload:', payload)
+        },
+      )
+      .subscribe()
+
+    // 3. 언마운트 시 구독 해제
+    return () => {
+      supabase.removeChannel(channel)
+    }
+  }
+
+  // 컴포넌트 초기화 시 기존 메시지 내역을 불러옴
+  useEffect(() => {
+    if (!params.nbreadId) {
+      useToast.error('잘못된 URL 주소입니다. 다시 시도해주세요.')
+      router.back()
+      return
+    }
+
+    try {
+      const nbreadId = params.nbreadId as string
+      setNbreadId(nbreadId)
+      fetchChatMessages(nbreadId)
+    } catch (error) {
+      useToast.error('메시지 내역을 불러오는 데 실패했어요.')
+      router.back()
+      return
+    }
+  }, [])
+
+  // nbreadId가 변경될 때마다 해당 엔빵의 채팅방을 구독
+  useEffect(() => {
+    subscribeChatRoom()
+  }, [nbreadId])
+
+  if (!hasFetched) {
+    return <div>메시지 로딩 중</div>
+  }
+
+  return (
+    <div>
+      <div>채팅방</div>
+      <div>
+        {chatMessages.length === 0 ? (
+          <div>아직 메시지가 없어요.</div>
+        ) : (
+          chatMessages.map((chatMessage, index) => (
+            <div key={index} className="flex flex-row justify-start gap-16">
+              <Avatar
+                size="small"
+                profileImageUrl={chatMessage.userProfileImage}
+              />
+              <div>{chatMessage.userName}</div>
+              <div>{chatMessage.content}</div>
+            </div>
+          ))
+        )}
+      </div>
+      <input
+        type="text"
+        value={inputText}
+        onChange={(event) => setInputText(event.target.value)}
+        onKeyPress={(event) => {
+          if (event.key === 'Enter' && inputText.trim() !== '') {
+            sendChatMessages(inputText)
+            setInputText('')
+          }
+        }}
+      />
+    </div>
+  )
+}
+
+export default Page

--- a/src/lib/chatMessage/getChatMessages.tsx
+++ b/src/lib/chatMessage/getChatMessages.tsx
@@ -1,0 +1,33 @@
+import { supabase } from '@/lib/supabaseClient'
+import { ChatMessage } from '@/types/chatMessage'
+
+/* getChatMessages: DB로부터 그룹 메시지 내역을 불러옴 */
+export const getChatMessages = async (nbreadId: string) => {
+  try {
+    const { data, error } = await supabase
+      .from('chat_messages')
+      .select('*')
+      .eq('nbread_id', nbreadId)
+
+    if (error || !data) {
+      console.error('Error get chat messages:', error)
+      throw error
+    }
+
+    // 불러온 row data를 ChatMessage 타입으로 매핑
+    const chatMessages: ChatMessage[] = data.map((item, index) => ({
+      id: item.id,
+      content: item.content,
+      nbreadId: item.nbread_id,
+      userId: item.user_id,
+      userName: item.user_name,
+      userProfileImage: item.user_profile_image,
+      createdAt: item.created_at,
+    }))
+
+    return chatMessages
+  } catch (error) {
+    console.error('Error get chat messages:', error)
+    throw error
+  }
+}

--- a/src/lib/chatMessage/insertChatMessage.tsx
+++ b/src/lib/chatMessage/insertChatMessage.tsx
@@ -1,0 +1,31 @@
+import { supabase } from '@/lib/supabaseClient'
+import { User } from '@/types/user'
+
+export const insertChatMessage = async (
+  user: User,
+  nbreadId: string,
+  content: string,
+) => {
+  try {
+    const { data, error } = await supabase
+      .from('chat_messages')
+      .insert({
+        nbread_id: nbreadId,
+        user_id: user.id,
+        user_name: user.name,
+        user_profile_image: user.profileImage,
+        content: content,
+      })
+      .select('id')
+      .single()
+
+    if (error) {
+      console.error('Error inserting chat messages:', error)
+      throw error
+    }
+
+    return data.id
+  } catch (error) {
+    throw error
+  }
+}

--- a/src/types/chatMessage.ts
+++ b/src/types/chatMessage.ts
@@ -1,0 +1,9 @@
+export interface ChatMessage {
+  id: string
+  content: string
+  nbreadId: string
+  userId: string
+  userName: string
+  userProfileImage: string
+  createdAt: string
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #96 

## 📝작업 내용

> 엔빵 내 그룹 채팅 기능을 구현했습니다.
> - 엔빵 채팅 내역을 저장하는 DB 테이블(`chat_messages`)을 새롭게 생성했습니다.
> - `chat_messages` 테이블로부터 해당 엔빵의 기존 채팅 내역을 불러오는 `getChatMessages` 메서드를 구현했습니다.
> - `chat_messages` 테이블에 새로운 메시지를 업데이트하는 `insertChatMessage` 메서드를 구현했습니다.
> - 엔빵의 채팅방을 구독하는 `subscribeChatRoom` 메서드 및 채팅방 기능을 구현했습니다.

### 스크린샷
<img width="715" alt="스크린샷 2025-05-27 오후 6 30 41" src="https://github.com/user-attachments/assets/d2203244-6f82-45c2-83a6-beee9a552681" />


## 💬리뷰 요구사항

> 채팅방 페이지는 현재 `/nbread/[nbreadId]/chat` 라우터로 임시로 구현해 뒀고, 상세페이지 라우터 맨 뒤에 `/chat`만 추가하시면 바로 확인하실 수 있습니다
> 일단 기능만 구현한 거라 나중에 퍼블리싱할 때 컴포넌트로 분리하시면 됩니다.
> 추가로 현재 page.tsx 파일 내에 전체 코드가 들어있는데 엔빵 상세 페이지 탭바로 분리하면서 이 페이지도 컴포넌트로 분리하면 될 것 같습니다!
> 구현 과정이나 수파베이스 Realtime 관련해서는 노션에 좀 더 자세히 적어두겠습니다 💦
