### PR TITLE
[feature-30/alarm] Supabase 알림 수정 및 추가 구현

### DIFF
--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -259,32 +259,32 @@ export type Database = {
       notification: {
         Row: {
           created_at: string
+          data: Json | null
           id: number
           is_read: boolean
           message: string
           title: string
           type: string
-          url: string
           user_id: string | null
         }
         Insert: {
           created_at?: string
+          data?: Json | null
           id?: number
           is_read: boolean
           message: string
           title: string
           type: string
-          url: string
           user_id?: string | null
         }
         Update: {
           created_at?: string
+          data?: Json | null
           id?: number
           is_read?: boolean
           message?: string
           title?: string
           type?: string
-          url?: string
           user_id?: string | null
         }
         Relationships: [

--- a/supabase/functions/chat-notification/deno.json
+++ b/supabase/functions/chat-notification/deno.json
@@ -1,4 +1,10 @@
 {
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true
+  },
   "imports": {
     "supabase": "npm:@supabase/supabase-js@2",
     "JWT": "npm:google-auth-library@9"

--- a/supabase/functions/chat-notification/index.ts
+++ b/supabase/functions/chat-notification/index.ts
@@ -128,9 +128,11 @@ Deno.serve(async (req) => {
         user_id,
         message,
         title,
-        url: '',
         is_read: false,
         type: 'payment',
+        data: {
+          nbreadId: nbreadId,
+        },
       })
     })
     return new Response(

--- a/supabase/functions/friend-request-notification/deno.json
+++ b/supabase/functions/friend-request-notification/deno.json
@@ -1,4 +1,10 @@
 {
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true
+  },
   "imports": {
     "supabase": "npm:@supabase/supabase-js@2",
     "JWT": "npm:google-auth-library@9"

--- a/supabase/functions/friend-request-notification/index.ts
+++ b/supabase/functions/friend-request-notification/index.ts
@@ -8,6 +8,7 @@ import {
 import { getFcmAccessToken } from '../utils/getFCMToken.ts'
 import { sendFCMNotification } from '../utils/sendFCMNotification.ts'
 import { insertNotificationResult } from '../utils/insertNotificationResult.ts'
+
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', {
@@ -24,6 +25,7 @@ Deno.serve(async (req) => {
   try {
     payload = await req.json()
   } catch (e) {
+    console.error(e)
     return new Response(
       JSON.stringify({
         error: 'Invalid payload',
@@ -79,7 +81,7 @@ Deno.serve(async (req) => {
 
     // 3. 친구 요청 응답자의 FCM 토큰 조회
     const fcmAccessToken = await getFcmAccessToken({
-      clientEmail: firebaseClientEmail,
+      clientEmail: firebaseClientEmail!,
       privateKey: firebasePrivateKey,
     })
 
@@ -99,11 +101,14 @@ Deno.serve(async (req) => {
         .map((_, idx) =>
           insertNotificationResult({
             user_id: fcmDeviceTokenData[idx].user_id,
-            message,
-            title,
+            message: message,
+            title: title,
             is_read: false,
             type: 'friend_request',
-            url: '',
+            data: {
+              sender_id: senderId,
+              sender_name: senderName,
+            },
           }),
         ),
     )

--- a/supabase/functions/friend-response-notification/.npmrc
+++ b/supabase/functions/friend-response-notification/.npmrc
@@ -1,0 +1,3 @@
+# Configuration for private npm package dependencies
+# For more information on using private registries with Edge Functions, see:
+# https://supabase.com/docs/guides/functions/import-maps#importing-from-private-registries

--- a/supabase/functions/friend-response-notification/deno.json
+++ b/supabase/functions/friend-response-notification/deno.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "imports": {
+    "supabase": "npm:@supabase/supabase-js@2",
+    "JWT": "npm:google-auth-library@9"
+  }
+}

--- a/supabase/functions/friend-response-notification/index.ts
+++ b/supabase/functions/friend-response-notification/index.ts
@@ -8,49 +8,46 @@ import {
 import { getFcmAccessToken } from '../utils/getFCMToken.ts'
 import { sendFCMNotification } from '../utils/sendFCMNotification.ts'
 import { insertNotificationResult } from '../utils/insertNotificationResult.ts'
+import { FriendRequestRow } from '../types/database.types.ts'
+
+interface WebhookPayload {
+  type: 'UPDATE'
+  table: string
+  record: FriendRequestRow
+  old_record: FriendRequestRow
+  schema: 'public'
+}
 
 Deno.serve(async (req) => {
-  if (req.method === 'OPTIONS') {
-    return new Response('ok', {
-      headers: corsHeaders,
-    })
+  const payload: WebhookPayload = await req.json()
+
+  if (payload.old_record.status === 'accepted') {
+    return new Response(null, { status: 204, headers: corsHeaders })
   }
+
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
   if (req.method !== 'POST') {
     return new Response('Method Not Allowed', {
       status: 405,
       headers: corsHeaders,
     })
   }
-  let payload
+
   try {
-    payload = await req.json()
-  } catch (e) {
-    console.error(e)
-    return new Response(
-      JSON.stringify({
-        error: 'Invalid payload',
-      }),
-      {
-        status: 400,
-        headers: corsHeaders,
-      },
-    )
-  }
-  try {
-    // 1. 친구 요청자 및 응답자 정보 저장
-    const senderId = payload.record.sender_id
     const receiverId = payload.record.receiver_id
-    const { data: senderNameData, error: senderNameError } =
+    const { data: receiverNameData, error: receiverNameDataError } =
       await supabaseClient
         .from('user')
         .select('name')
-        .eq('id', senderId)
+        .eq('id', receiverId)
         .single()
-    if (senderNameError || !senderNameData) {
+    if (receiverNameDataError || !receiverNameData) {
+      console.error(receiverNameDataError)
       return new Response(
-        JSON.stringify({
-          error: 'Failed to get sender name',
-        }),
+        JSON.stringify({ error: 'Failed to get receiver name' }),
         {
           status: 500,
           headers: corsHeaders,
@@ -58,15 +55,19 @@ Deno.serve(async (req) => {
       )
     }
 
-    // 2. 친구 요청 메시지 생성
-    const senderName = senderNameData.name
-    const title = `🍞 ${senderName}님의 친구 요청`
-    const message = `${senderName}님이 친구 요청을 보냈어요`
+    // 2. status에 따라 친구 요청 수락 / 거절 메시지 생성
+    const requestAccepted = payload.record.status === 'accepted' ? true : false
+    const title = requestAccepted ? '🍞 친구 요청 수락' : '🍞 친구 요청 거절'
+    const message = requestAccepted
+      ? `${receiverNameData.name}님이 친구 요청을 수락했어요`
+      : `${receiverNameData.name}님이 친구 요청을 거절했어요`
+
     const { data: fcmDeviceTokenData, error: fcmDeviceTokenError } =
       await supabaseClient
         .from('fcm_token')
         .select('*')
         .eq('user_id', receiverId)
+
     if (fcmDeviceTokenError || !fcmDeviceTokenData) {
       return new Response(
         JSON.stringify({
@@ -88,7 +89,7 @@ Deno.serve(async (req) => {
     const fcmDeviceTokens = fcmDeviceTokenData.map((row) => row.fcm_token)
 
     // 4. 친구 요청 응답자에 대해 FCM 알림 발송
-    const notificationPromises = fcmDeviceTokens.map((token) =>
+    const notificationPromises = fcmDeviceTokens.map((token: string) =>
       sendFCMNotification(token, fcmAccessToken, title, message),
     )
 
@@ -97,25 +98,24 @@ Deno.serve(async (req) => {
     // 5. 알림 발송 결과를 서버에 저장
     await Promise.all(
       results
-        .filter((result) => result.status === 'SUCCESS')
-        .map((_, idx) =>
+        .filter((result: FriendRequestRow) => result.status === 'SUCCESS')
+        .map((_: FriendRequestRow, idx: number) =>
           insertNotificationResult({
             user_id: fcmDeviceTokenData[idx].user_id,
             message: message,
             title: title,
             is_read: false,
-            type: 'friend_request',
+            type: 'friend_response',
             data: {
-              sender_id: senderId,
-              sender_name: senderName,
+              response: payload.record.status,
+              receiver_id: receiverId,
+              sender_name: receiverNameData.name,
             },
           }),
         ),
     )
     return new Response(
-      JSON.stringify({
-        message: 'Notification sent successfully',
-      }),
+      JSON.stringify({ message: 'Notification sent successfully' }),
       {
         status: 200,
         headers: corsHeaders,
@@ -123,14 +123,9 @@ Deno.serve(async (req) => {
     )
   } catch (e) {
     console.error('Unexpected error:', e)
-    return new Response(
-      JSON.stringify({
-        error: 'Unexpected error',
-      }),
-      {
-        status: 500,
-        headers: corsHeaders,
-      },
-    )
+    return new Response(JSON.stringify({ error: 'Unexpected error' }), {
+      status: 500,
+      headers: corsHeaders,
+    })
   }
 })

--- a/supabase/functions/payment-notification/deno.json
+++ b/supabase/functions/payment-notification/deno.json
@@ -1,4 +1,10 @@
 {
+  "compilerOptions": {
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true
+  },
   "imports": {
     "supabase": "npm:@supabase/supabase-js@2",
     "JWT": "npm:google-auth-library@9"

--- a/supabase/functions/payment-notification/index.ts
+++ b/supabase/functions/payment-notification/index.ts
@@ -8,7 +8,6 @@ import {
 import { getFcmAccessToken } from '../utils/getFCMToken.ts'
 import { sendFCMNotification } from '../utils/sendFCMNotification.ts'
 import { insertNotificationResult } from '../utils/insertNotificationResult.ts'
-import { UpdatePayload } from '../types/types.ts'
 import { NbreadRecordsRow } from '../types/database.types.ts'
 
 interface WebhookPayload {
@@ -147,12 +146,14 @@ Deno.serve(async (req) => {
 
     notifiedUserMap.forEach((_, user_id) => {
       insertNotificationResult({
-        user_id,
-        message,
-        title,
-        url: '',
+        user_id: user_id,
+        message: message,
+        title: title,
         is_read: false,
         type: 'payment',
+        data: {
+          nbread_id: nbreadId,
+        },
       })
     })
     return new Response(

--- a/supabase/functions/types/database.types.ts
+++ b/supabase/functions/types/database.types.ts
@@ -7,7 +7,7 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instanciate createClient with right options
+  // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
     PostgrestVersion: '12.2.3 (519615d)'
@@ -87,6 +87,54 @@ export type Database = {
             referencedColumns: ['id']
           },
         ]
+      }
+      friend: {
+        Row: {
+          created_at: string
+          id: number
+          user_id_1: string
+          user_id_2: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          user_id_1: string
+          user_id_2: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          user_id_1?: string
+          user_id_2?: string
+        }
+        Relationships: []
+      }
+      friend_request: {
+        Row: {
+          created_at: string
+          id: number
+          receiver_id: string
+          responded_at: string | null
+          sender_id: string
+          status: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          receiver_id: string
+          responded_at?: string | null
+          sender_id: string
+          status: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          receiver_id?: string
+          responded_at?: string | null
+          sender_id?: string
+          status?: string
+        }
+        Relationships: []
       }
       nbread: {
         Row: {
@@ -211,32 +259,32 @@ export type Database = {
       notification: {
         Row: {
           created_at: string
+          data: Json | null
           id: number
           is_read: boolean
           message: string
           title: string
           type: string
-          url: string
           user_id: string | null
         }
         Insert: {
           created_at?: string
+          data?: Json | null
           id?: number
           is_read: boolean
           message: string
           title: string
           type: string
-          url: string
           user_id?: string | null
         }
         Update: {
           created_at?: string
+          data?: Json | null
           id?: number
           is_read?: boolean
           message?: string
           title?: string
           type?: string
-          url?: string
           user_id?: string | null
         }
         Relationships: [
@@ -290,22 +338,28 @@ export type Database = {
           content: string | null
           created_at: string
           id: number
+          nbread_id: string
           profile_image: string | null
           user_id: string | null
+          user_name: string | null
         }
         Insert: {
           content?: string | null
           created_at?: string
           id?: number
+          nbread_id: string
           profile_image?: string | null
           user_id?: string | null
+          user_name?: string | null
         }
         Update: {
           content?: string | null
           created_at?: string
           id?: number
+          nbread_id?: string
           profile_image?: string | null
           user_id?: string | null
+          user_name?: string | null
         }
         Relationships: [
           {
@@ -374,7 +428,7 @@ export type NbreadRecordsRow =
   Database['public']['Tables']['nbread_records']['Row']
 export type NotificationRow =
   Database['public']['Tables']['notification']['Row']
-export type ChatMessageRow =
-  Database['public']['Tables']['chat_messages']['Row']
 export type FriendRequestRow =
   Database['public']['Tables']['friend_request']['Row']
+export type ChatMessageRow =
+  Database['public']['Tables']['chat_messages']['Row']

--- a/supabase/functions/types/types.ts
+++ b/supabase/functions/types/types.ts
@@ -1,10 +1,12 @@
+import { Json } from './database.types.ts'
+
 export interface Notification {
   user_id: string
   title: string
   message: string
-  url: string
   is_read: boolean
-  type: 'payment' | 'invite' | 'invite_accept' | 'follow'
+  type: 'payment' | 'invite' | 'invite_accept' | 'friend_request'
+  data: Json
 }
 
 export type TableRecord<T> = T

--- a/supabase/functions/types/types.ts
+++ b/supabase/functions/types/types.ts
@@ -5,7 +5,12 @@ export interface Notification {
   title: string
   message: string
   is_read: boolean
-  type: 'payment' | 'invite' | 'invite_accept' | 'friend_request'
+  type:
+    | 'payment'
+    | 'invite'
+    | 'invite_accept'
+    | 'friend_request'
+    | 'friend_response'
   data: Json
 }
 

--- a/supabase/functions/utils/insertNotificationResult.ts
+++ b/supabase/functions/utils/insertNotificationResult.ts
@@ -10,7 +10,7 @@ export const insertNotificationResult = async (
         user_id: notificationData.user_id,
         title: notificationData.title,
         message: notificationData.message,
-        url: notificationData.url,
+        data: notificationData.data,
         is_read: notificationData.is_read,
         type: notificationData.type,
       })


### PR DESCRIPTION
## #️⃣연관된 이슈

> #91 

## 📝작업 내용

> 각 알림 별로 필요한 data를 추가했습니다.
> - DB notification 테이블에 JSON으로 필요 데이터를 저장하는  data 컬럼을 추가했습니다.
> - friend-request 알림 발행 시 `senderId`, `senderName`을 data에 저장하도록 변경했습니다.
> - chat 알림, payment 알림 발행 시 `nbreadId`를 data에 저장하도록 변경했습니다.

> 친구 요청 수락/거절 알림을 구현했습니다.
> - `friend-response` edge function을 구현했습니다.
> - `friend-request` 테이블의 `status` 컬럼이 업데이트될 때 알림을 발행합니다.
> - `status`가 `accepted`로 변경된 경우 친구 요청 수락 알림을, `rejected`로 변경된 경우 거절 알림을 발행하도록 구현했습니다.
> - `notification` 테이블의 `data`에 `status`, `receiverId`, `receiverName` 값을 JSON 형태로 저장합니다.

### 스크린샷 (선택)
X

## 💬리뷰 요구사항(선택)
> data 컬럼에 이상 없는지 확인 부탁드립니다.
