### PR TITLE
[feature-30/alarm] PWA + Supabase 알림 기능 추가 구현

### DIFF
--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -4,13 +4,16 @@ import DetailHeader from '@/components/common/header/DetailHeader'
 import { getNotification } from '@/lib/notification'
 import useUserStore from '@/stores/useAuthStore'
 import { Notification } from '@/types/notification'
-import Icon from '@/components/common/icon/Icon'
 import Spinner from '@/components/common/spinner/Spinner'
+import { useToast } from '@/components/common/toast/Toast'
+import { useRouter } from 'next/navigation'
+import { Json } from '@/types/supabase'
 
 const Page = () => {
   const [notificationData, setNotificationData] = useState<Notification[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const userData = useUserStore((state) => state.user)
+  const router = useRouter()
 
   const fetchNotifications = async () => {
     setIsLoading(true)
@@ -19,9 +22,11 @@ const Page = () => {
       (a, b) => Number(new Date(b.created_at)) - Number(new Date(a.created_at)),
     )
     setNotificationData(sortedDataByCreatedAt)
+    console.log(sortedDataByCreatedAt)
     setIsLoading(false)
   }
 
+  // ----------- 태평양시 기준 시간을 알림 기준 시간으로 변경하는 함수 ----------- //
   function getRelativeTime(utcDateString: string): string {
     const KST_OFFSET = 9 * 60 * 60 * 1000 // 한국은 UTC+9
     const now = new Date(Date.now() + KST_OFFSET)
@@ -43,6 +48,33 @@ const Page = () => {
     return `${year}년 전`
   }
 
+  // -------------- 알림 아이템 클릭 시 알림 타입에 따라 처리하는 함수 ------------- //
+  function notificationOnclickHandler(type: string, data: Json | null) {
+    const parsedData = data as Record<string, unknown>
+
+    console.log(type, data)
+    if (!type || !data) {
+      useToast.error('잘못된 요청입니다. 다시 시도해주세요.')
+      return
+    }
+
+    switch (type) {
+      // chat, payment : 해당 엔빵 페이지로 이동
+      case 'chat':
+      case 'payment':
+        const nbreadId = parsedData['nbreadId'] as string
+        router.replace(`/nbread/${nbreadId}`)
+        break
+      case 'nbread-invite':
+        // NOTE 엔빵 초대 관련 로직 추가
+        break
+
+      case 'friend-request':
+        // NOTE 친구 초대 관련 로직 추가
+        break
+    }
+  }
+
   useEffect(() => {
     if (userData) {
       fetchNotifications()
@@ -54,49 +86,29 @@ const Page = () => {
   }
 
   return (
-    <div className="jusfity-between flex h-screen w-full flex-col overflow-y-hidden">
+    <div className="jusfity-between flex h-full w-full flex-col overflow-y-hidden">
       <div className="pl-24 pt-24">
         <DetailHeader />
       </div>
       <div className="mb-16 flex flex-row items-end justify-between px-24 pt-24">
         <header className="text-heading02 text-gray-800">알림</header>
-        <div
-          className="cursor-pointer pb-2 text-body02 text-gray-400"
-          onClick={
-            () => null // TODO 알림 모두 지우기 함수 추가
-          }
-        >
-          모두 지우기
-        </div>
       </div>
 
-      <div className="flex flex-col justify-between gap-8 px-20">
-        {notificationData.map((data, index) => (
+      <div className="flex flex-col justify-between gap-8 overflow-y-auto px-20 pb-40 pt-4">
+        {notificationData.map((item, _) => (
           <div
             className="card card-clickable relative flex cursor-pointer flex-row justify-between"
-            key={data.id}
+            key={item.id}
+            onClick={() => notificationOnclickHandler(item.type, item.data)}
           >
             <div className="flex w-full flex-col gap-4">
-              <div className="text-body01 text-gray-800">{data.title}</div>
+              <div className="text-body01 text-gray-800">{item.title}</div>
               <div className="flex w-full flex-row justify-between">
-                <div className="text-body02 text-gray-600">{data.message}</div>
+                <div className="text-body02 text-gray-600">{item.message}</div>
                 <div className="text-body02 text-gray-300">
-                  {getRelativeTime(data.created_at)}
+                  {getRelativeTime(item.created_at)}
                 </div>
               </div>
-            </div>
-            <div
-              className="absolute right-12 top-12 cursor-pointer"
-              onClick={
-                () => null // TODO 알림 삭제 함수 추가
-              }
-            >
-              <Icon
-                type={'cross'}
-                width={16}
-                height={16}
-                fill={'text-gray-400'}
-              />
             </div>
           </div>
         ))}

--- a/src/lib/notification/getNotifications.ts
+++ b/src/lib/notification/getNotifications.ts
@@ -27,7 +27,7 @@ export const getNotification = async (userId: string) => {
         created_at: notification.created_at,
         title: notification.title,
         message: notification.message,
-        url: notification.url,
+        data: notification.data,
         type: notification.type,
         is_read: notification.is_read,
       }),

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,10 +1,12 @@
+import { Json } from './supabase'
+
 export interface Notification {
   id: number
   user_id: string
   created_at: string
   title: string
   message: string
-  url: string | null
+  data: Json | null
   is_read: boolean
   type: string // TODO 알림 타입 수정 필요
 }

--- a/supabase/functions/friend-response-notification/index.ts
+++ b/supabase/functions/friend-response-notification/index.ts
@@ -37,6 +37,7 @@ Deno.serve(async (req) => {
   }
 
   try {
+    const senderId = payload.record.sender_id
     const receiverId = payload.record.receiver_id
     const { data: receiverNameData, error: receiverNameDataError } =
       await supabaseClient
@@ -63,10 +64,7 @@ Deno.serve(async (req) => {
       : `${receiverNameData.name}님이 친구 요청을 거절했어요`
 
     const { data: fcmDeviceTokenData, error: fcmDeviceTokenError } =
-      await supabaseClient
-        .from('fcm_token')
-        .select('*')
-        .eq('user_id', receiverId)
+      await supabaseClient.from('fcm_token').select('*').eq('user_id', senderId)
 
     if (fcmDeviceTokenError || !fcmDeviceTokenData) {
       return new Response(

--- a/supabase/functions/friend-response-notification/index.ts
+++ b/supabase/functions/friend-response-notification/index.ts
@@ -96,8 +96,8 @@ Deno.serve(async (req) => {
     // 5. 알림 발송 결과를 서버에 저장
     await Promise.all(
       results
-        .filter((result: FriendRequestRow) => result.status === 'SUCCESS')
-        .map((_: FriendRequestRow, idx: number) =>
+        .filter((result) => result.status === 'SUCCESS')
+        .map((_, idx: number) =>
           insertNotificationResult({
             user_id: fcmDeviceTokenData[idx].user_id,
             message: message,

--- a/supabase/functions/nbread-invite-accept-notificatiion/index.ts
+++ b/supabase/functions/nbread-invite-accept-notificatiion/index.ts
@@ -1,0 +1,176 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+import { supabaseClient } from '../_shared/createClient.ts'
+import { corsHeaders } from '../_shared/cors.ts'
+import {
+  firebaseClientEmail,
+  firebasePrivateKey,
+} from '../_shared/environment.ts'
+import { getFcmAccessToken } from '../utils/getFCMToken.ts'
+import { sendFCMNotification } from '../utils/sendFCMNotification.ts'
+import { insertNotificationResult } from '../utils/insertNotificationResult.ts'
+import { NbreadInviteRow } from '../types/database.types.ts'
+
+interface WebhookPayload {
+  type: 'UPDATE'
+  table: string
+  record: NbreadInviteRow
+  old_record: NbreadInviteRow
+  schema: 'public'
+}
+
+Deno.serve(async (req) => {
+  const payload: WebhookPayload = await req.json()
+
+  if (payload.old_record.state === 'accepted') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: corsHeaders,
+    })
+  }
+
+  try {
+    const invitedUserId = payload.record.invited_user_id
+    const nbreadId = payload.record.nbread_id
+
+    // 초대받은 유저의 이름을 불러옴
+    const { data: invitedUserNameData, error: invitedUserNameDataError } =
+      await supabaseClient
+        .from('user')
+        .select('name')
+        .eq('id', invitedUserId)
+        .single()
+    if (invitedUserNameDataError || !invitedUserNameData) {
+      console.error(invitedUserNameDataError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to get invited user name' }),
+        {
+          status: 500,
+          headers: corsHeaders,
+        },
+      )
+    }
+
+    // 해당 엔빵의 이름을 불러옴
+    const { data: nbreadNameData, error: nbreadNameDataError } =
+      await supabaseClient
+        .from('nbread')
+        .select('title')
+        .eq('id', nbreadId)
+        .single()
+    if (nbreadNameDataError || !nbreadNameData) {
+      console.error(nbreadNameDataError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to get nbread name' }),
+        {
+          status: 500,
+          headers: corsHeaders,
+        },
+      )
+    }
+
+    // 알림 데이터 생성
+    const title = '🍞 엔빵 초대 수락'
+    const message = `${invitedUserNameData.name}님이 ${nbreadNameData.title}에 참여했어요`
+
+    // 1. nbread에 참여한 모든 사용자 ID 조회
+    const { data: participantsData, error: participantsDataError } =
+      await supabaseClient
+        .from('participant')
+        .select('user_id')
+        .eq('nbread_id', nbreadId)
+    if (participantsDataError || !participantsData) {
+      console.error(participantsDataError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to get participants' }),
+        {
+          status: 500,
+          headers: corsHeaders,
+        },
+      )
+    }
+
+    // 2. 초대를 수락한 유저 제외
+    const targetUserIds = participantsData
+      .map((row) => row.user_id)
+      .filter((id) => id !== invitedUserId)
+
+    // 3. 해당 user_id들에 대한 FCM 토큰 조회
+    const { data: fcmDeviceTokenData, error: fcmDeviceTokenError } =
+      await supabaseClient
+        .from('fcm_token')
+        .select('*')
+        .in('user_id', targetUserIds)
+
+    if (
+      fcmDeviceTokenError ||
+      !fcmDeviceTokenData ||
+      fcmDeviceTokenData.length === 0
+    ) {
+      return new Response(JSON.stringify({ error: 'No FCM tokens found' }), {
+        status: 500,
+        headers: corsHeaders,
+      })
+    }
+    const fcmDeviceTokens = fcmDeviceTokenData.map((row) => row.fcm_token)
+
+    // 4. FCM 서버에 알림 전송
+    const fcmAccessToken = await getFcmAccessToken({
+      clientEmail: firebaseClientEmail!,
+      privateKey: firebasePrivateKey!,
+    })
+
+    const notificationPromises = fcmDeviceTokens.map((deviceToken) =>
+      sendFCMNotification(deviceToken, fcmAccessToken, title, message),
+    )
+
+    const results = await Promise.all(notificationPromises)
+
+    // 5. FCM 알림 성공 여부에 따라 DB에 알림 저장
+    const successTokenSet = new Set(
+      results
+        .filter((result) => result.status === 'SUCCESS')
+        .map((result) => result.fcmToken),
+    )
+
+    const notifiedUserMap = new Map<string, string>()
+
+    fcmDeviceTokenData.forEach(({ user_id, fcm_token }) => {
+      if (successTokenSet.has(fcm_token) && !notifiedUserMap.has(user_id)) {
+        notifiedUserMap.set(user_id, fcm_token)
+      }
+    })
+
+    notifiedUserMap.forEach((_, user_id) => {
+      insertNotificationResult({
+        user_id,
+        message,
+        title,
+        is_read: false,
+        type: 'payment',
+        data: {
+          nbreadId: nbreadId,
+        },
+      })
+    })
+    return new Response(
+      JSON.stringify({ message: 'Notification sent successfully' }),
+      {
+        status: 200,
+        headers: corsHeaders,
+      },
+    )
+  } catch (e) {
+    console.error('Unexpected error:', e)
+    return new Response(JSON.stringify({ error: 'Unexpected error' }), {
+      status: 500,
+      headers: corsHeaders,
+    })
+  }
+})

--- a/supabase/functions/nbread-invite-notification/index.ts
+++ b/supabase/functions/nbread-invite-notification/index.ts
@@ -1,0 +1,130 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+import { supabaseClient } from '../_shared/createClient.ts'
+import { corsHeaders } from '../_shared/cors.ts'
+import {
+  firebaseClientEmail,
+  firebasePrivateKey,
+} from '../_shared/environment.ts'
+import { getFcmAccessToken } from '../utils/getFCMToken.ts'
+import { sendFCMNotification } from '../utils/sendFCMNotification.ts'
+import { insertNotificationResult } from '../utils/insertNotificationResult.ts'
+import { NbreadInviteRow } from '../types/database.types.ts'
+
+interface WebhookPayload {
+  type: 'INSERT'
+  table: string
+  record: NbreadInviteRow
+  schema: 'public'
+}
+
+Deno.serve(async (req) => {
+  const payload: WebhookPayload = await req.json()
+
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST') {
+    return new Response('Method Not Allowed', {
+      status: 405,
+      headers: corsHeaders,
+    })
+  }
+
+  try {
+    const nbreadId = payload.record.nbread_id
+    const { data: nbreadTitle, error: nbreadTitleError } = await supabaseClient
+      .from('nbread')
+      .select('title')
+      .eq('id', nbreadId)
+      .single()
+
+    if (nbreadTitleError || !nbreadTitle) {
+      console.error(nbreadTitleError)
+      return new Response(
+        JSON.stringify({ error: 'Failed to get nbread title' }),
+        {
+          status: 500,
+          headers: corsHeaders,
+        },
+      )
+    }
+
+    const invitedUserId = payload.record.invited_user_id
+
+    const title = '🍞 엔빵 초대 알림'
+    const message = `${nbreadTitle.title}에서 초대가 도착했어요`
+
+    // 1. 초대된 user_id에 대한 FCM 토큰 조회
+    const { data: fcmDeviceTokenData, error: fcmDeviceTokenError } =
+      await supabaseClient
+        .from('fcm_token')
+        .select('*')
+        .in('user_id', [invitedUserId])
+
+    if (
+      fcmDeviceTokenError ||
+      !fcmDeviceTokenData ||
+      fcmDeviceTokenData.length === 0
+    ) {
+      return new Response(JSON.stringify({ error: 'No FCM tokens found' }), {
+        status: 500,
+        headers: corsHeaders,
+      })
+    }
+    const fcmDeviceTokens = fcmDeviceTokenData.map((row) => row.fcm_token)
+
+    // 2. FCM 서버에 알림 전송
+    const fcmAccessToken = await getFcmAccessToken({
+      clientEmail: firebaseClientEmail!,
+      privateKey: firebasePrivateKey!,
+    })
+
+    const notificationPromises = fcmDeviceTokens.map((deviceToken) =>
+      sendFCMNotification(deviceToken, fcmAccessToken, title, message),
+    )
+
+    const results = await Promise.all(notificationPromises)
+
+    // 3. FCM 알림 성공 여부에 따라 DB에 알림 저장
+    const successTokenSet = new Set(
+      results
+        .filter((result) => result.status === 'SUCCESS')
+        .map((result) => result.fcmToken),
+    )
+
+    const notifiedUserMap = new Map<string, string>()
+
+    fcmDeviceTokenData.forEach(({ user_id, fcm_token }) => {
+      if (successTokenSet.has(fcm_token) && !notifiedUserMap.has(user_id)) {
+        notifiedUserMap.set(user_id, fcm_token)
+      }
+    })
+
+    notifiedUserMap.forEach((_, user_id) => {
+      insertNotificationResult({
+        user_id,
+        message,
+        title,
+        is_read: false,
+        type: 'payment',
+        data: {
+          nbreadId: nbreadId,
+        },
+      })
+    })
+    return new Response(
+      JSON.stringify({ message: 'Notification sent successfully' }),
+      {
+        status: 200,
+        headers: corsHeaders,
+      },
+    )
+  } catch (e) {
+    console.error('Unexpected error:', e)
+    return new Response(JSON.stringify({ error: 'Unexpected error' }), {
+      status: 500,
+      headers: corsHeaders,
+    })
+  }
+})

--- a/supabase/functions/types/database.types.ts
+++ b/supabase/functions/types/database.types.ts
@@ -424,6 +424,8 @@ export type Database = {
 export type UserRow = Database['public']['Tables']['user']['Row']
 export type ParticipantRow = Database['public']['Tables']['participant']['Row']
 export type NbreadRow = Database['public']['Tables']['nbread']['Row']
+export type NbreadInviteRow =
+  Database['public']['Tables']['nbread_invite']['Row']
 export type NbreadRecordsRow =
   Database['public']['Tables']['nbread_records']['Row']
 export type NotificationRow =


### PR DESCRIPTION
## #️⃣연관된 이슈

> #91

## 📝작업 내용

> 알림 페이지를 수정하고 알림 클릭 시 라우팅을 일부 구현했습니다.
> - 알림 페이지 스크롤이 가능하도록 변경했습니다.
> - 알림 리스트 클릭 시 해당하는 페이지로 이동하는 로직을 일부 구현했습니다.
> 엔빵 초대, 친구 추가 관련 로직은 주석에 `NOTE`로 표시된 부분에 추가하면 됩니다.

> 엔빵 초대 및 초대 수락 알림을 구현했습니다.
> - 엔빵 초대 알림을 edge function으로 구현했습니다.
> - 엔빵 초대 수락 알림을 edge function으로 구현했습니다.
> - 구현한 edge function을 supabase 프로젝트에 배포하고 webhook에 연결했습니다.

### 스크린샷 (선택)
x

## 💬리뷰 요구사항(선택)
> 알림 클릭 시 추가되어야 하는 친구 추가, 엔빵 초대 관련 로직은 주석의 NOTE 부분에 추가하면 됩니다.
> 엔빵 초대 및 수락 알림이 제대로 동작하지 않는 경우 말씀 부탁드립니다.