### PR TITLE
[fix-42/invite-notification] 엔빵 초대 및 초대 수락 알림 수정

### DIFF
--- a/supabase/functions/nbread-invite-accept-notificatiion/index.ts
+++ b/supabase/functions/nbread-invite-accept-notificatiion/index.ts
@@ -153,7 +153,7 @@ Deno.serve(async (req) => {
         message,
         title,
         is_read: false,
-        type: 'payment',
+        type: 'invite_accept',
         data: {
           nbreadId: nbreadId,
         },

--- a/supabase/functions/nbread-invite-notification/index.ts
+++ b/supabase/functions/nbread-invite-notification/index.ts
@@ -107,7 +107,7 @@ Deno.serve(async (req) => {
         message,
         title,
         is_read: false,
-        type: 'payment',
+        type: 'invite',
         data: {
           nbreadId: nbreadId,
         },


### PR DESCRIPTION
## #️⃣연관된 이슈

> #121 

## 📝작업 내용

> 엔빵 초대 알림 및 엔빵 초대 수락 알림의 type을 각각 `invite`, `invite_accept`로 수정했습니다.
> 위 2개 알림의 data에는 우선적으로 `nbreadId`만 저장하고, 추후 변경이 필요한 경우 추가할 예정입니다.

### 스크린샷 (선택)
X

## 💬리뷰 요구사항(선택)
> X