### PR TITLE
[feature-44/update-nbread-records] 정산 내역 자동 업데이트 기능 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "update-types": "supabase gen types typescript --project-id whsygotpggvtadynqwmv --schema public > src/types/supabase.ts"
+    "update-types": "supabase gen types typescript --project-id yyisakaqnaoomehqlyjz --schema public > src/types/supabase.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.47.14",

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -45,26 +45,27 @@ export default function CalendarPage() {
     if (!selectedDate) return []
 
     const filtered = nbreadList.filter((nbread) => {
-      const currentPaymentDate = nbread.currentPaymentDate
-        ? new Date(nbread.currentPaymentDate)
-        : null
-      const nextPaymentDate = nbread.paymentDate
+      const startDate = nbread.startDate ? new Date(nbread.startDate) : null
+      const endDate = nbread.endDate ? new Date(nbread.endDate) : null
+      const paymentDate = nbread.paymentDate
         ? new Date(nbread.paymentDate)
         : null
 
-      // currentPaymentDate와 nextPaymentDate가 유효하지 않으면 필터링에서 제외
-      if (!currentPaymentDate && !nextPaymentDate) return false
+      if (!startDate && !endDate && !paymentDate) return false
 
-      // selectedDate와 currentPaymentDate 또는 nextPaymentDate를 비교
       const isSameDate =
-        (currentPaymentDate &&
-          currentPaymentDate.getDate() === selectedDate.getDate() &&
-          currentPaymentDate.getMonth() === selectedDate.getMonth() &&
-          currentPaymentDate.getFullYear() === selectedDate.getFullYear()) ||
-        (nextPaymentDate &&
-          nextPaymentDate.getDate() === selectedDate.getDate() &&
-          nextPaymentDate.getMonth() === selectedDate.getMonth() &&
-          nextPaymentDate.getFullYear() === selectedDate.getFullYear())
+        (startDate &&
+          startDate.getDate() === selectedDate.getDate() &&
+          startDate.getMonth() === selectedDate.getMonth() &&
+          startDate.getFullYear() === selectedDate.getFullYear()) ||
+        (endDate &&
+          endDate.getDate() === selectedDate.getDate() &&
+          endDate.getMonth() === selectedDate.getMonth() &&
+          endDate.getFullYear() === selectedDate.getFullYear()) ||
+        (paymentDate &&
+          paymentDate.getDate() === selectedDate.getDate() &&
+          paymentDate.getMonth() === selectedDate.getMonth() &&
+          paymentDate.getFullYear() === selectedDate.getFullYear())
 
       return isSameDate
     })

--- a/src/app/nbread/[nbreadId]/page.tsx
+++ b/src/app/nbread/[nbreadId]/page.tsx
@@ -67,7 +67,7 @@ const Page = () => {
     const fetchNbreadRecordData = async () => {
       const nbreadRecordsData = await getNbreadRecords(
         nbread!.id,
-        nbread!.currentPaymentDate!,
+        nbread!.startDate!,
       )
       setNbreadRecords(nbreadRecordsData)
     }

--- a/src/components/common/modal/NbreadInviteModal.tsx
+++ b/src/components/common/modal/NbreadInviteModal.tsx
@@ -42,7 +42,7 @@ const NbreadInviteModal = ({
         title: `${user?.name}님이 엔빵으로 초대했어요!`,
         description: '참여하기를 클릭해 초대를 수락해보세요.',
         imageUrl:
-          'https://whsygotpggvtadynqwmv.supabase.co/storage/v1/object/public/service-image//nbread-service-image-text.png',
+          'https://yyisakaqnaoomehqlyjz.supabase.co/storage/v1/object/public/service-image//nbread-service-image-text.png',
         link: {
           mobileWebUrl: inviteLink, // 모바일 웹에서 열릴 URL
           webUrl: inviteLink, // 웹에서 열릴 URL
@@ -89,7 +89,7 @@ const NbreadInviteModal = ({
         <div className="flex flex-col items-center gap-8 pb-12">
           <button
             onClick={handleCopyLink}
-            className="btn btn-medium text-heading06 bg-system-blue01 hover:bg-system-blue02 text-white"
+            className="btn btn-medium text-heading06 bg-system-blue01 text-white hover:bg-system-blue02"
           >
             <div className="flex w-full flex-row items-center justify-start px-20">
               <Icon type="copy" width={14} height={14} fill="text-white" />

--- a/src/components/nbread/NbreadDetail.tsx
+++ b/src/components/nbread/NbreadDetail.tsx
@@ -117,7 +117,7 @@ const nbreadDetail = ({ nbreadData, setNbreadData }: nbreadDetailProps) => {
     const fetchNbreadRecordData = async () => {
       const nbreadRecordsData = await getNbreadRecords(
         nbreadData!.id,
-        nbreadData!.currentPaymentDate!,
+        nbreadData!.startDate!,
       )
       setNbreadRecords(nbreadRecordsData)
     }
@@ -164,7 +164,7 @@ const nbreadDetail = ({ nbreadData, setNbreadData }: nbreadDetailProps) => {
               <NbreadParticipantsList
                 nbreadId={nbreadData.id}
                 nbreadRecords={nbreadRecords!}
-                currentPaymentDate={nbreadData.currentPaymentDate!}
+                startDate={nbreadData.startDate!}
                 participants={nbreadData.participants!}
                 participantMaxCount={nbreadData.participantCount}
                 leaderId={nbreadData.leaderId!}

--- a/src/components/nbread/nbreadParticipantCard.tsx
+++ b/src/components/nbread/nbreadParticipantCard.tsx
@@ -9,7 +9,7 @@ import { useRef, useState } from 'react'
 interface NbreadParticipantCardProps {
   nbreadId?: string
   participantId?: string
-  currentPaymentDate?: string
+  startDate?: string
   profileImageUrl?: string | null
   isNbreadLeader: boolean
   name: string
@@ -35,7 +35,7 @@ const NbreadParticipantCard = (props: NbreadParticipantCardProps) => {
         props.nbreadId!,
         props.participantId!,
         !isChecked,
-        props.currentPaymentDate!,
+        props.startDate!,
       )
 
       useToast.success('완료 여부 업데이트에 성공했어요.')

--- a/src/components/nbread/nbreadParticipantsList.tsx
+++ b/src/components/nbread/nbreadParticipantsList.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react'
 interface NbreadParticipantsListProps {
   nbreadId: string
   nbreadRecords: NbreadRecord[]
-  currentPaymentDate: string
+  startDate: string
   participants: Participant[]
   participantMaxCount: number
   paymentAmount: number
@@ -23,7 +23,7 @@ interface NbreadParticipantsListProps {
 
 const NbreadParticipantsList = ({
   nbreadId,
-  currentPaymentDate,
+  startDate,
   nbreadRecords,
   participants,
   participantMaxCount,
@@ -87,7 +87,7 @@ const NbreadParticipantsList = ({
                 key={index}
                 nbreadId={nbreadId}
                 participantId={participant.user.id}
-                currentPaymentDate={currentPaymentDate}
+                startDate={startDate}
                 isNbreadLeader={participant.isLeader}
                 name={participant.user.name}
                 profileImageUrl={participant.user.profileImage}
@@ -119,7 +119,7 @@ const NbreadParticipantsList = ({
                 key={index}
                 nbreadId={nbreadId}
                 participantId={participants[index].user.id}
-                currentPaymentDate={currentPaymentDate}
+                startDate={startDate}
                 isNbreadLeader={participants[index].isLeader}
                 name={participants[index].user.name}
                 profileImageUrl={participants[index].user.profileImage}

--- a/src/lib/nbread/getNbread.ts
+++ b/src/lib/nbread/getNbread.ts
@@ -28,7 +28,8 @@ export const getNbread = async (nbreadId: string) => {
       paymentPeriod: data.payment_period as 'year' | 'month',
       leaderId: data.leader_id,
       participants: null,
-      currentPaymentDate: data.current_payment_date,
+      startDate: data.start_date,
+      endDate: data.end_date,
       paidCount: null,
     }
 

--- a/src/lib/nbread/getUserNbread.ts
+++ b/src/lib/nbread/getUserNbread.ts
@@ -46,7 +46,8 @@ export const getUserNbreads = async (userId: string): Promise<Nbread[]> => {
       paymentPeriod: nbread.payment_period as 'year' | 'month',
       leaderId: nbread.leader_id,
       participants: null,
-      currentPaymentDate: nbread.current_payment_date,
+      startDate: nbread.start_date,
+      endDate: nbread.end_date,
     }),
   )
 
@@ -57,7 +58,7 @@ export const getUserNbreads = async (userId: string): Promise<Nbread[]> => {
         .from('nbread_records')
         .select('*', { count: 'exact' })
         .eq('nbread_id', nbread.id)
-        .eq('payment_date', nbread.currentPaymentDate)
+        .eq('payment_date', nbread.startDate)
         .eq('is_paid', true)
 
       if (error) {

--- a/src/lib/nbreadRecord/getNbreadRecords.ts
+++ b/src/lib/nbreadRecord/getNbreadRecords.ts
@@ -3,9 +3,9 @@ import { Nbread, NbreadRecord } from '@/types/nbread'
 
 export const getNbreadRecords = async (
   nbreadId: string,
-  currentPaymentDate: string,
+  startDate: string,
 ) => {
-  const translatedCurrentPaymentDate = new Date(currentPaymentDate)
+  const translatedStartDate = new Date(startDate)
     .toISOString()
     .split('T')[0]
 
@@ -14,7 +14,7 @@ export const getNbreadRecords = async (
       .from('nbread_records')
       .select('*')
       .eq('nbread_id', nbreadId)
-      .eq('payment_date', translatedCurrentPaymentDate) // payment-date가 currentPaymentDate와 동일한 row만 불러오기
+      .eq('payment_date', translatedStartDate)
 
     if (error) {
       console.error('Error fetching nbread record:', error)

--- a/src/lib/nbreadRecord/updateNbreadRecord.ts
+++ b/src/lib/nbreadRecord/updateNbreadRecord.ts
@@ -5,9 +5,9 @@ export const updateNbreadRecord = async (
   nbreadId: string,
   userId: string,
   isPaid: boolean,
-  currentPaymentDate: string,
+  startDate: string,
 ) => {
-  const translatedCurrentPaymentDate = new Date(currentPaymentDate)
+  const translatedStartDate = new Date(startDate)
     .toISOString()
     .split('T')[0]
 
@@ -19,7 +19,7 @@ export const updateNbreadRecord = async (
       })
       .eq('nbread_id', nbreadId)
       .eq('user_id', userId)
-      .eq('payment_date', translatedCurrentPaymentDate) // payment-date가 currentPaymentDate와 동일한 row만 업데이트(가장 최신 row만 업데이트)
+      .eq('payment_date', translatedStartDate)
 
     if (error) {
       console.error('Error updating nbread record:', error)

--- a/src/types/nbread.ts
+++ b/src/types/nbread.ts
@@ -10,7 +10,8 @@ export interface Nbread {
   paymentDate: number | null
   leaderId: string | null
   participants: Participant[] | null
-  currentPaymentDate: string | null
+  startDate: string | null
+  endDate?: string | null
   paidCount?: number | null
 }
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -139,38 +139,38 @@ export type Database = {
       nbread: {
         Row: {
           amount: number
-          current_payment_date: string | null
+          end_date: string | null
           id: string
           leader_id: string
-          next_payment_date: string | null
           participant_count: number
           payment_date: number
           payment_month: number | null
           payment_period: string
+          start_date: string | null
           title: string
         }
         Insert: {
           amount: number
-          current_payment_date?: string | null
+          end_date?: string | null
           id?: string
           leader_id: string
-          next_payment_date?: string | null
           participant_count: number
           payment_date: number
           payment_month?: number | null
           payment_period: string
+          start_date?: string | null
           title: string
         }
         Update: {
           amount?: number
-          current_payment_date?: string | null
+          end_date?: string | null
           id?: string
           leader_id?: string
-          next_payment_date?: string | null
           participant_count?: number
           payment_date?: number
           payment_month?: number | null
           payment_period?: string
+          start_date?: string | null
           title?: string
         }
         Relationships: []
@@ -252,6 +252,59 @@ export type Database = {
             columns: ['user_id']
             isOneToOne: false
             referencedRelation: 'user'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      nbread_auto_generation_logs: {
+        Row: {
+          created_at: string
+          end_date: string | null
+          error_message: string | null
+          id: number
+          inserted_count: number
+          metadata: Json
+          nbread_id: string | null
+          next_payment_date: string | null
+          payment_date: string | null
+          reason: string | null
+          start_date: string | null
+          status: string
+        }
+        Insert: {
+          created_at?: string
+          end_date?: string | null
+          error_message?: string | null
+          id?: number
+          inserted_count?: number
+          metadata?: Json
+          nbread_id?: string | null
+          next_payment_date?: string | null
+          payment_date?: string | null
+          reason?: string | null
+          start_date?: string | null
+          status: string
+        }
+        Update: {
+          created_at?: string
+          end_date?: string | null
+          error_message?: string | null
+          id?: number
+          inserted_count?: number
+          metadata?: Json
+          nbread_id?: string | null
+          next_payment_date?: string | null
+          payment_date?: string | null
+          reason?: string | null
+          start_date?: string | null
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'nbread_auto_generation_logs_nbread_id_fkey'
+            columns: ['nbread_id']
+            isOneToOne: false
+            referencedRelation: 'nbread'
             referencedColumns: ['id']
           },
         ]
@@ -406,6 +459,22 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      calculate_next_nbread_payment_date: {
+        Args: {
+          p_payment_date: string
+          p_payment_period: string
+          p_payment_month: number
+          p_payment_day: number
+        }
+        Returns: string
+      }
+      generate_nbread_records_for_due_group: {
+        Args: {
+          p_nbread_id: string
+          p_today?: string
+        }
+        Returns: Json
+      }
       update_nbread_records: {
         Args: Record<PropertyKey, never>
         Returns: undefined

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -341,3 +341,9 @@ entrypoint = "./functions/chat-notification/index.ts"
 # Specifies static files to be bundled with the function. Supports glob patterns.
 # For example, if you want to serve static HTML pages in your function:
 # static_files = [ "./functions/chat-notification/*.html" ]
+
+[functions.auto-generate-nbread-records]
+enabled = true
+verify_jwt = false
+import_map = "./functions/auto-generate-nbread-records/deno.json"
+entrypoint = "./functions/auto-generate-nbread-records/index.ts"

--- a/supabase/cron/auto-generate-nbread-records.sql
+++ b/supabase/cron/auto-generate-nbread-records.sql
@@ -1,0 +1,44 @@
+-- Run this once in the Supabase SQL Editor after deploying the Edge Function.
+-- Replace the placeholders before executing.
+
+create extension if not exists supabase_vault with schema vault;
+
+select vault.create_secret(
+  'https://<PROJECT_REF>.supabase.co',
+  'project_url'
+);
+
+select vault.create_secret(
+  '<CRON_SECRET>',
+  'nbread_auto_generate_cron_secret'
+);
+
+select cron.unschedule('auto-generate-nbread-records')
+where exists (
+  select 1
+  from cron.job
+  where jobname = 'auto-generate-nbread-records'
+);
+
+select cron.schedule(
+  'auto-generate-nbread-records',
+  '0 15 * * *',
+  $$
+  select net.http_post(
+    url := (
+      select decrypted_secret
+      from vault.decrypted_secrets
+      where name = 'project_url'
+    ) || '/functions/v1/auto-generate-nbread-records',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (
+        select decrypted_secret
+        from vault.decrypted_secrets
+        where name = 'nbread_auto_generate_cron_secret'
+      )
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);

--- a/supabase/functions/auto-generate-nbread-records/deno.json
+++ b/supabase/functions/auto-generate-nbread-records/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2"
+  }
+}

--- a/supabase/functions/auto-generate-nbread-records/index.ts
+++ b/supabase/functions/auto-generate-nbread-records/index.ts
@@ -1,0 +1,139 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+import { supabaseClient } from '../_shared/createClient.ts'
+import { corsHeaders } from '../_shared/cors.ts'
+
+type RpcResult = {
+  status?: 'success' | 'skipped' | 'error'
+  reason?: string
+  nbread_id?: string
+  start_date?: string
+  end_date?: string
+  payment_date?: string
+  inserted_count?: number
+  existing_count?: number
+}
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...corsHeaders,
+      'Content-Type': 'application/json',
+    },
+  })
+
+const getDateInTimeZone = (timeZone: string) =>
+  new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date())
+
+const insertLog = async ({
+  nbreadId,
+  result,
+  errorMessage,
+}: {
+  nbreadId: string | null
+  result: RpcResult
+  errorMessage?: string
+}) => {
+  const { error } = await supabaseClient
+    .from('nbread_auto_generation_logs')
+    .insert({
+      nbread_id: nbreadId,
+      status: result.status ?? (errorMessage ? 'error' : 'skipped'),
+      reason: result.reason ?? null,
+      payment_date: result.payment_date ?? result.start_date ?? null,
+      start_date: result.start_date ?? null,
+      end_date: result.end_date ?? null,
+      inserted_count: result.inserted_count ?? 0,
+      error_message: errorMessage ?? null,
+      metadata: result,
+    })
+
+  if (error) {
+    console.error('Failed to insert auto generation log:', error)
+  }
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    return jsonResponse({ error: 'Method Not Allowed' }, 405)
+  }
+
+  const cronSecret = Deno.env.get('CRON_SECRET')
+  if (cronSecret && req.headers.get('x-cron-secret') !== cronSecret) {
+    return jsonResponse({ error: 'Unauthorized' }, 401)
+  }
+
+  const paymentTimeZone = Deno.env.get('PAYMENT_TIME_ZONE') ?? 'Asia/Seoul'
+  const today = getDateInTimeZone(paymentTimeZone)
+
+  const { data: dueNbreads, error: dueNbreadsError } = await supabaseClient
+    .from('nbread')
+    .select('id, start_date, end_date')
+    .not('start_date', 'is', null)
+    .not('end_date', 'is', null)
+    .lt('end_date', today)
+
+  if (dueNbreadsError) {
+    console.error('Failed to fetch due nbreads:', dueNbreadsError)
+    return jsonResponse({ error: 'Failed to fetch due nbreads' }, 500)
+  }
+
+  const results = []
+
+  for (const nbread of dueNbreads ?? []) {
+    const { data, error } = await supabaseClient.rpc(
+      'generate_nbread_records_for_due_group',
+      {
+        p_nbread_id: nbread.id,
+        p_today: today,
+      },
+    )
+
+    if (error) {
+      console.error(
+        `Failed to generate records for nbread ${nbread.id}:`,
+        error,
+      )
+      const result: RpcResult = {
+        status: 'error',
+        reason: 'rpc_failed',
+        nbread_id: nbread.id,
+      }
+
+      await insertLog({
+        nbreadId: nbread.id,
+        result,
+        errorMessage: error.message,
+      })
+
+      results.push({ ...result, error: error.message })
+      continue
+    }
+
+    const result = data as RpcResult
+    await insertLog({
+      nbreadId: result.nbread_id ?? nbread.id,
+      result,
+    })
+    results.push(result)
+  }
+
+  return jsonResponse({
+    processedCount: results.length,
+    successCount: results.filter((result) => result.status === 'success')
+      .length,
+    skippedCount: results.filter((result) => result.status === 'skipped')
+      .length,
+    errorCount: results.filter((result) => result.status === 'error').length,
+    results,
+  })
+})

--- a/supabase/functions/types/database.types.ts
+++ b/supabase/functions/types/database.types.ts
@@ -139,38 +139,38 @@ export type Database = {
       nbread: {
         Row: {
           amount: number
-          current_payment_date: string | null
+          end_date: string | null
           id: string
           leader_id: string
-          next_payment_date: string | null
           participant_count: number
           payment_date: number
           payment_month: number | null
           payment_period: string
+          start_date: string | null
           title: string
         }
         Insert: {
           amount: number
-          current_payment_date?: string | null
+          end_date?: string | null
           id?: string
           leader_id: string
-          next_payment_date?: string | null
           participant_count: number
           payment_date: number
           payment_month?: number | null
           payment_period: string
+          start_date?: string | null
           title: string
         }
         Update: {
           amount?: number
-          current_payment_date?: string | null
+          end_date?: string | null
           id?: string
           leader_id?: string
-          next_payment_date?: string | null
           participant_count?: number
           payment_date?: number
           payment_month?: number | null
           payment_period?: string
+          start_date?: string | null
           title?: string
         }
         Relationships: []
@@ -252,6 +252,59 @@ export type Database = {
             columns: ['user_id']
             isOneToOne: false
             referencedRelation: 'user'
+            referencedColumns: ['id']
+          },
+        ]
+      }
+      nbread_auto_generation_logs: {
+        Row: {
+          created_at: string
+          end_date: string | null
+          error_message: string | null
+          id: number
+          inserted_count: number
+          metadata: Json
+          nbread_id: string | null
+          next_payment_date: string | null
+          payment_date: string | null
+          reason: string | null
+          start_date: string | null
+          status: string
+        }
+        Insert: {
+          created_at?: string
+          end_date?: string | null
+          error_message?: string | null
+          id?: number
+          inserted_count?: number
+          metadata?: Json
+          nbread_id?: string | null
+          next_payment_date?: string | null
+          payment_date?: string | null
+          reason?: string | null
+          start_date?: string | null
+          status: string
+        }
+        Update: {
+          created_at?: string
+          end_date?: string | null
+          error_message?: string | null
+          id?: number
+          inserted_count?: number
+          metadata?: Json
+          nbread_id?: string | null
+          next_payment_date?: string | null
+          payment_date?: string | null
+          reason?: string | null
+          start_date?: string | null
+          status?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: 'nbread_auto_generation_logs_nbread_id_fkey'
+            columns: ['nbread_id']
+            isOneToOne: false
+            referencedRelation: 'nbread'
             referencedColumns: ['id']
           },
         ]
@@ -403,6 +456,22 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      calculate_next_nbread_payment_date: {
+        Args: {
+          p_payment_date: string
+          p_payment_period: string
+          p_payment_month: number
+          p_payment_day: number
+        }
+        Returns: string
+      }
+      generate_nbread_records_for_due_group: {
+        Args: {
+          p_nbread_id: string
+          p_today?: string
+        }
+        Returns: Json
+      }
       update_nbread_records: {
         Args: Record<PropertyKey, never>
         Returns: undefined

--- a/supabase/migrations/20260517101517_auto_generate_nbread_records.sql
+++ b/supabase/migrations/20260517101517_auto_generate_nbread_records.sql
@@ -1,0 +1,200 @@
+create extension if not exists pg_cron;
+create extension if not exists pg_net;
+
+create table if not exists public.nbread_auto_generation_logs (
+  id bigserial primary key,
+  nbread_id uuid references public.nbread(id) on delete set null,
+  status text not null check (status in ('success', 'skipped', 'error')),
+  reason text,
+  payment_date date,
+  next_payment_date date,
+  inserted_count integer not null default 0,
+  error_message text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+alter table public.nbread_auto_generation_logs enable row level security;
+
+with duplicate_groups as (
+  select
+    nbread_id,
+    payment_date,
+    user_id,
+    min(id) as keep_id,
+    bool_or(is_paid) as merged_is_paid,
+    min(created_at) as first_created_at
+  from public.nbread_records
+  group by nbread_id, payment_date, user_id
+  having count(*) > 1
+),
+merged_records as (
+  update public.nbread_records records
+  set is_paid = duplicate_groups.merged_is_paid,
+      created_at = duplicate_groups.first_created_at
+  from duplicate_groups
+  where records.id = duplicate_groups.keep_id
+  returning records.id
+)
+delete from public.nbread_records records
+using duplicate_groups
+where records.nbread_id = duplicate_groups.nbread_id
+  and records.payment_date = duplicate_groups.payment_date
+  and records.user_id = duplicate_groups.user_id
+  and records.id <> duplicate_groups.keep_id;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'nbread_records_nbread_id_payment_date_user_id_key'
+      and conrelid = 'public.nbread_records'::regclass
+  ) then
+    alter table public.nbread_records
+      add constraint nbread_records_nbread_id_payment_date_user_id_key
+      unique (nbread_id, payment_date, user_id);
+  end if;
+end $$;
+
+create or replace function public.calculate_next_nbread_payment_date(
+  p_payment_date date,
+  p_payment_period text,
+  p_payment_month integer,
+  p_payment_day integer
+)
+returns date
+language plpgsql
+immutable
+as $$
+declare
+  target_month date;
+  max_day integer;
+begin
+  if p_payment_date is null then
+    return null;
+  end if;
+
+  if p_payment_day is null or p_payment_day < 1 or p_payment_day > 31 then
+    raise exception 'Invalid payment day: %', p_payment_day;
+  end if;
+
+  if p_payment_period = 'month' then
+    target_month := (date_trunc('month', p_payment_date)::date + interval '1 month')::date;
+  elsif p_payment_period = 'year' then
+    target_month := make_date(
+      extract(year from p_payment_date)::integer + 1,
+      coalesce(nullif(p_payment_month, 0), extract(month from p_payment_date)::integer),
+      1
+    );
+  else
+    raise exception 'Unsupported payment period: %', p_payment_period;
+  end if;
+
+  max_day := extract(
+    day from (target_month + interval '1 month - 1 day')
+  )::integer;
+
+  return target_month + (least(p_payment_day, max_day) - 1);
+end;
+$$;
+
+create or replace function public.generate_nbread_records_for_due_group(
+  p_nbread_id uuid,
+  p_today date default current_date
+)
+returns jsonb
+language plpgsql
+as $$
+declare
+  target_nbread public.nbread%rowtype;
+  due_payment_date date;
+  next_due_payment_date date;
+  existing_count integer;
+  inserted_count integer;
+begin
+  select *
+  into target_nbread
+  from public.nbread
+  where id = p_nbread_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'nbread_not_found',
+      'nbread_id', p_nbread_id
+    );
+  end if;
+
+  due_payment_date := target_nbread.next_payment_date::date;
+
+  if due_payment_date is null then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'next_payment_date_is_null',
+      'nbread_id', p_nbread_id
+    );
+  end if;
+
+  if due_payment_date > p_today then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'not_due',
+      'nbread_id', p_nbread_id,
+      'payment_date', due_payment_date
+    );
+  end if;
+
+  next_due_payment_date := public.calculate_next_nbread_payment_date(
+    due_payment_date,
+    target_nbread.payment_period,
+    target_nbread.payment_month,
+    target_nbread.payment_date
+  );
+
+  select count(*)
+  into existing_count
+  from public.nbread_records
+  where nbread_id = target_nbread.id
+    and payment_date = due_payment_date;
+
+  if existing_count > 0 then
+    update public.nbread
+    set current_payment_date = due_payment_date,
+        next_payment_date = next_due_payment_date
+    where id = target_nbread.id;
+
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'records_already_exist',
+      'nbread_id', target_nbread.id,
+      'payment_date', due_payment_date,
+      'next_payment_date', next_due_payment_date,
+      'existing_count', existing_count
+    );
+  end if;
+
+  insert into public.nbread_records (nbread_id, user_id, payment_date, is_paid)
+  select participant.nbread_id, participant.user_id, due_payment_date, false
+  from public.participant
+  where participant.nbread_id = target_nbread.id
+  on conflict (nbread_id, payment_date, user_id) do nothing;
+
+  get diagnostics inserted_count = row_count;
+
+  update public.nbread
+  set current_payment_date = due_payment_date,
+      next_payment_date = next_due_payment_date
+  where id = target_nbread.id;
+
+  return jsonb_build_object(
+    'status', 'success',
+    'reason', 'records_created',
+    'nbread_id', target_nbread.id,
+    'payment_date', due_payment_date,
+    'next_payment_date', next_due_payment_date,
+    'inserted_count', inserted_count
+  );
+end;
+$$;

--- a/supabase/migrations/20260518043355_restrict_init_payment_dates_trigger.sql
+++ b/supabase/migrations/20260518043355_restrict_init_payment_dates_trigger.sql
@@ -1,0 +1,7 @@
+drop trigger if exists trigger_init_payment_dates on public.nbread;
+
+create trigger trigger_init_payment_dates
+before insert or update of payment_period, payment_month, payment_date
+on public.nbread
+for each row
+execute function public.init_payment_dates();

--- a/supabase/migrations/20260518051937_fix_nbread_auto_generation_cycle.sql
+++ b/supabase/migrations/20260518051937_fix_nbread_auto_generation_cycle.sql
@@ -1,0 +1,113 @@
+create or replace function public.generate_nbread_records_for_due_group(
+  p_nbread_id uuid,
+  p_today date default current_date
+)
+returns jsonb
+language plpgsql
+as $$
+declare
+  target_nbread public.nbread%rowtype;
+  settlement_payment_date date;
+  record_payment_date date;
+  next_record_payment_date date;
+  existing_count integer;
+  inserted_count integer;
+begin
+  select *
+  into target_nbread
+  from public.nbread
+  where id = p_nbread_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'nbread_not_found',
+      'nbread_id', p_nbread_id
+    );
+  end if;
+
+  settlement_payment_date := target_nbread.current_payment_date::date;
+  record_payment_date := target_nbread.next_payment_date::date;
+
+  if settlement_payment_date is null then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'current_payment_date_is_null',
+      'nbread_id', p_nbread_id
+    );
+  end if;
+
+  if record_payment_date is null then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'next_payment_date_is_null',
+      'nbread_id', p_nbread_id,
+      'settlement_date', settlement_payment_date
+    );
+  end if;
+
+  if settlement_payment_date > p_today then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'not_due',
+      'nbread_id', p_nbread_id,
+      'settlement_date', settlement_payment_date,
+      'payment_date', record_payment_date
+    );
+  end if;
+
+  next_record_payment_date := public.calculate_next_nbread_payment_date(
+    record_payment_date,
+    target_nbread.payment_period,
+    target_nbread.payment_month,
+    target_nbread.payment_date
+  );
+
+  select count(*)
+  into existing_count
+  from public.nbread_records
+  where nbread_id = target_nbread.id
+    and payment_date = record_payment_date;
+
+  if existing_count > 0 then
+    update public.nbread
+    set current_payment_date = record_payment_date,
+        next_payment_date = next_record_payment_date
+    where id = target_nbread.id;
+
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'records_already_exist',
+      'nbread_id', target_nbread.id,
+      'settlement_date', settlement_payment_date,
+      'payment_date', record_payment_date,
+      'next_payment_date', next_record_payment_date,
+      'existing_count', existing_count
+    );
+  end if;
+
+  insert into public.nbread_records (nbread_id, user_id, payment_date, is_paid)
+  select participant.nbread_id, participant.user_id, record_payment_date, false
+  from public.participant
+  where participant.nbread_id = target_nbread.id
+  on conflict (nbread_id, payment_date, user_id) do nothing;
+
+  get diagnostics inserted_count = row_count;
+
+  update public.nbread
+  set current_payment_date = record_payment_date,
+      next_payment_date = next_record_payment_date
+  where id = target_nbread.id;
+
+  return jsonb_build_object(
+    'status', 'success',
+    'reason', 'records_created',
+    'nbread_id', target_nbread.id,
+    'settlement_date', settlement_payment_date,
+    'payment_date', record_payment_date,
+    'next_payment_date', next_record_payment_date,
+    'inserted_count', inserted_count
+  );
+end;
+$$;

--- a/supabase/migrations/20260518053956_rename_nbread_payment_dates_to_period_dates.sql
+++ b/supabase/migrations/20260518053956_rename_nbread_payment_dates_to_period_dates.sql
@@ -1,0 +1,219 @@
+drop trigger if exists trigger_init_payment_dates on public.nbread;
+
+alter table public.nbread
+rename column current_payment_date to start_date;
+
+alter table public.nbread
+rename column next_payment_date to end_date;
+
+update public.nbread
+set end_date = end_date - 1
+where end_date is not null;
+
+alter table public.nbread_auto_generation_logs
+add column if not exists start_date date,
+add column if not exists end_date date;
+
+create or replace function public.calculate_nbread_period_start(
+  p_today date,
+  p_payment_period text,
+  p_payment_month integer,
+  p_payment_day integer
+)
+returns date
+language plpgsql
+immutable
+as $$
+declare
+  candidate_month date;
+  target_month date;
+  max_day integer;
+  candidate_date date;
+begin
+  if p_payment_period = 'month' then
+    candidate_month := date_trunc('month', p_today)::date;
+  elsif p_payment_period = 'year' then
+    if p_payment_month is null then
+      raise exception 'payment_month is required for yearly nbread';
+    end if;
+
+    candidate_month := make_date(
+      extract(year from p_today)::integer,
+      p_payment_month,
+      1
+    );
+  else
+    raise exception 'Unsupported payment period: %', p_payment_period;
+  end if;
+
+  max_day := extract(
+    day from (candidate_month + interval '1 month - 1 day')
+  )::integer;
+
+  candidate_date := candidate_month + (least(p_payment_day, max_day) - 1);
+
+  if candidate_date <= p_today then
+    return candidate_date;
+  end if;
+
+  if p_payment_period = 'month' then
+    target_month := candidate_month - interval '1 month';
+  else
+    target_month := candidate_month - interval '1 year';
+  end if;
+
+  max_day := extract(
+    day from (target_month + interval '1 month - 1 day')
+  )::integer;
+
+  return target_month + (least(p_payment_day, max_day) - 1);
+end;
+$$;
+
+create or replace function public.init_payment_dates()
+returns trigger
+language plpgsql
+as $$
+declare
+  period_start date;
+  next_period_start date;
+begin
+  period_start := public.calculate_nbread_period_start(
+    current_date,
+    new.payment_period,
+    new.payment_month,
+    new.payment_date
+  );
+
+  next_period_start := public.calculate_next_nbread_payment_date(
+    period_start,
+    new.payment_period,
+    new.payment_month,
+    new.payment_date
+  );
+
+  new.start_date := period_start;
+  new.end_date := next_period_start - 1;
+
+  return new;
+end;
+$$;
+
+create trigger trigger_init_payment_dates
+before insert or update of payment_period, payment_month, payment_date
+on public.nbread
+for each row
+execute function public.init_payment_dates();
+
+create or replace function public.generate_nbread_records_for_due_group(
+  p_nbread_id uuid,
+  p_today date default current_date
+)
+returns jsonb
+language plpgsql
+as $$
+declare
+  target_nbread public.nbread%rowtype;
+  new_start_date date;
+  new_end_date date;
+  next_start_date date;
+  existing_count integer;
+  inserted_count integer;
+begin
+  select *
+  into target_nbread
+  from public.nbread
+  where id = p_nbread_id
+  for update;
+
+  if not found then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'nbread_not_found',
+      'nbread_id', p_nbread_id
+    );
+  end if;
+
+  if target_nbread.start_date is null then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'start_date_is_null',
+      'nbread_id', p_nbread_id
+    );
+  end if;
+
+  if target_nbread.end_date is null then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'end_date_is_null',
+      'nbread_id', p_nbread_id,
+      'start_date', target_nbread.start_date
+    );
+  end if;
+
+  if target_nbread.end_date >= p_today then
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'period_not_ended',
+      'nbread_id', target_nbread.id,
+      'start_date', target_nbread.start_date,
+      'end_date', target_nbread.end_date
+    );
+  end if;
+
+  new_start_date := target_nbread.end_date + 1;
+  next_start_date := public.calculate_next_nbread_payment_date(
+    new_start_date,
+    target_nbread.payment_period,
+    target_nbread.payment_month,
+    target_nbread.payment_date
+  );
+  new_end_date := next_start_date - 1;
+
+  select count(*)
+  into existing_count
+  from public.nbread_records
+  where nbread_id = target_nbread.id
+    and payment_date = new_start_date;
+
+  if existing_count > 0 then
+    update public.nbread
+    set start_date = new_start_date,
+        end_date = new_end_date
+    where id = target_nbread.id;
+
+    return jsonb_build_object(
+      'status', 'skipped',
+      'reason', 'records_already_exist',
+      'nbread_id', target_nbread.id,
+      'start_date', new_start_date,
+      'end_date', new_end_date,
+      'payment_date', new_start_date,
+      'existing_count', existing_count
+    );
+  end if;
+
+  insert into public.nbread_records (nbread_id, user_id, payment_date, is_paid)
+  select participant.nbread_id, participant.user_id, new_start_date, false
+  from public.participant
+  where participant.nbread_id = target_nbread.id
+  on conflict (nbread_id, payment_date, user_id) do nothing;
+
+  get diagnostics inserted_count = row_count;
+
+  update public.nbread
+  set start_date = new_start_date,
+      end_date = new_end_date
+  where id = target_nbread.id;
+
+  return jsonb_build_object(
+    'status', 'success',
+    'reason', 'records_created',
+    'nbread_id', target_nbread.id,
+    'start_date', new_start_date,
+    'end_date', new_end_date,
+    'payment_date', new_start_date,
+    'inserted_count', inserted_count
+  );
+end;
+$$;

--- a/supabase/migrations/20260518060953_fix_initial_nbread_records_start_date.sql
+++ b/supabase/migrations/20260518060953_fix_initial_nbread_records_start_date.sql
@@ -1,0 +1,23 @@
+create or replace function public.create_initial_nbread_records()
+returns trigger
+language plpgsql
+as $$
+declare
+  period_start date;
+begin
+  select n.start_date
+  into period_start
+  from public.nbread n
+  where n.id = new.nbread_id;
+
+  if period_start is null then
+    return new;
+  end if;
+
+  insert into public.nbread_records (nbread_id, user_id, payment_date, is_paid)
+  values (new.nbread_id, new.user_id, period_start, false)
+  on conflict (nbread_id, payment_date, user_id) do nothing;
+
+  return new;
+end;
+$$;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #129 

## 📝작업 내용

### 정산 내역 데이터 생성 DB Function 구현

- `nbread`의 정산 기준 컬럼을 `current_payment_date`, `next_payment_date`에서 `start_date`, `end_date`로 변경했습니다.
- 정산 기간 종료 후 다음 정산 기간을 계산하고 `nbread_records`를 생성하는 DB Function을 구현했습니다.
- 동일 정산 기간/참여자에 대한 중복 `nbread_records` 생성을 방지하도록 unique constraint와 conflict 처리 로직을 반영했습니다.
- 엔빵 생성 및 참여자 추가 시 최초 정산 기록이 `start_date` 기준으로 생성되도록 trigger function을 수정했습니다.

### 정산 대상 조회 및 생성 반복 처리 Edge Function 구현

- `auto-generate-nbread-records` Edge Function을 추가해 정산 종료일이 지난 엔빵을 조회하도록 구현했습니다.
- 조회된 엔빵을 순회하며 DB Function을 호출하고, 성공/스킵/에러 결과를 집계해 응답하도록 구성했습니다.
- 처리 결과를 `nbread_auto_generation_logs`에 저장해 향후 알림 및 로그 확인 기능 확장이 가능하도록 했습니다.
- `CRON_SECRET` 헤더 검증을 추가해 Cron 호출 외 접근을 제한할 수 있도록 구성했습니다.

### Supabase Cron 기반 자동 실행 구현

- Supabase Cron에서 매일 자정(KST)에 Edge Function을 호출하도록 SQL 스크립트를 추가했습니다.
- Vault에 저장된 `project_url`, `nbread_auto_generate_cron_secret`을 사용해 Cron에서 비밀값을 직접 노출하지 않도록 구성했습니다.
- 새 Supabase 프로젝트 ref 기준으로 타입 생성 스크립트와 초대 이미지 URL을 갱신했습니다.
- 프론트 정산 상세/참여자/캘린더 로직이 `startDate`, `endDate` 기준으로 동작하도록 반영했습니다.

### 스크린샷 (선택)

X

## 💬리뷰 요구사항(선택)

X