### PR TITLE
[refactor-52/chatroom-render] 채팅방 렌더링 성능 최적화

### DIFF
--- a/src/components/chat/ChatRoom.tsx
+++ b/src/components/chat/ChatRoom.tsx
@@ -1,15 +1,58 @@
 'use client'
 
-import Avatar from '@/components/common/avatar/avatar'
 import { useToast } from '@/components/common/toast/Toast'
 import { getChatMessages } from '@/lib/chatMessage/getChatMessages'
-import { useRouter, useParams } from 'next/navigation'
-import { ChatMessage } from '@/types/chatMessage'
-import { useEffect, useState, useRef } from 'react'
-import useUserStore from '@/stores/useAuthStore'
 import { insertChatMessage } from '@/lib/chatMessage/insertChatMessage'
 import { supabase } from '@/lib/supabaseClient'
+import useUserStore from '@/stores/useAuthStore'
+import { ChatMessage } from '@/types/chatMessage'
+import { useParams, useRouter } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Spinner from '../common/spinner/Spinner'
+import MessageList from './MessageList'
+
+const sortMessagesByCreatedAt = (messages: ChatMessage[]) =>
+  [...messages].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  )
+
+const isMatchingOptimisticMessage = (
+  optimisticMessage: ChatMessage,
+  realMessage: ChatMessage,
+) => {
+  const optimisticCreatedAt = Date.parse(optimisticMessage.createdAt)
+  const realCreatedAt = Date.parse(realMessage.createdAt)
+  const createdAtDiff = Math.abs(realCreatedAt - optimisticCreatedAt)
+
+  return (
+    optimisticMessage.id.startsWith('temp-') &&
+    optimisticMessage.userId === realMessage.userId &&
+    optimisticMessage.nbreadId === realMessage.nbreadId &&
+    optimisticMessage.content === realMessage.content &&
+    createdAtDiff < 60_000
+  )
+}
+
+const mergeIncomingMessage = (
+  messages: ChatMessage[],
+  incomingMessage: ChatMessage,
+) => {
+  if (messages.some((message) => message.id === incomingMessage.id)) {
+    return messages
+  }
+
+  const optimisticIndex = messages.findIndex((message) =>
+    isMatchingOptimisticMessage(message, incomingMessage),
+  )
+
+  if (optimisticIndex >= 0) {
+    return messages.map((message, index) =>
+      index === optimisticIndex ? incomingMessage : message,
+    )
+  }
+
+  return sortMessagesByCreatedAt([...messages, incomingMessage])
+}
 
 const ChatRoom = () => {
   const params = useParams()
@@ -17,59 +60,82 @@ const ChatRoom = () => {
   const user = useUserStore((state) => state.user)
   const bottomRef = useRef<HTMLDivElement | null>(null)
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
-  const [nbreadId, setNbreadId] = useState<string>('')
   const [inputText, setInputText] = useState<string>('')
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>([])
   const [hasFetched, setHasFetched] = useState<boolean>(false)
-  const [scrollState, setScrollState] = useState(false)
 
-  const fetchChatMessages = async (nbreadId: string) => {
-    const data = await getChatMessages(nbreadId)
-    const sortedData = data.sort(
-      (a, b) =>
-        new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-    )
-    setChatMessages(sortedData)
+  const nbreadId = useMemo(() => {
+    const routeNbreadId = params.nbreadId
+    return typeof routeNbreadId === 'string' ? routeNbreadId : ''
+  }, [params.nbreadId])
+
+  const fetchChatMessages = useCallback(async (targetNbreadId: string) => {
+    const data = await getChatMessages(targetNbreadId)
+    setChatMessages(sortMessagesByCreatedAt(data))
     setHasFetched(true)
-  }
+  }, [])
 
-  const sendChatMessages = async (content: string) => {
-    if (!params.nbreadId) {
+  const sendChatMessages = useCallback(
+    async (content: string) => {
+      if (!nbreadId || !user) {
+        useToast.error('잘못된 URL 주소입니다. 다시 시도해주세요.')
+        router.back()
+        return
+      }
+
+      const tempId = `temp-${Date.now()}`
+      const optimisticMessage: ChatMessage = {
+        id: tempId,
+        content,
+        userId: user.id,
+        userName: user.name,
+        userProfileImage: user.profileImage,
+        nbreadId,
+        createdAt: new Date().toISOString(),
+        status: 'sending',
+      }
+
+      setChatMessages((prev) => [...prev, optimisticMessage])
+
+      try {
+        const savedMessage = await insertChatMessage(user, nbreadId, content)
+
+        setChatMessages((prev) => {
+          const withoutTemp = prev.filter((message) => message.id !== tempId)
+          return mergeIncomingMessage(withoutTemp, savedMessage)
+        })
+      } catch {
+        setChatMessages((prev) =>
+          prev.map((message) =>
+            message.id === tempId ? { ...message, status: 'failed' } : message,
+          ),
+        )
+        useToast.error('메시지 전송에 실패했어요.')
+      }
+    },
+    [nbreadId, router, user],
+  )
+
+  useEffect(() => {
+    if (!nbreadId) {
       useToast.error('잘못된 URL 주소입니다. 다시 시도해주세요.')
       router.back()
       return
     }
-    const nbreadId = params.nbreadId as string
-    await insertChatMessage(user!, nbreadId, content)
-    setTimeout(() => {
-      setScrollState(true)
-    }, 100)
-  }
+
+    fetchChatMessages(nbreadId).catch(() => {
+      useToast.error('메시지 내역을 불러오는 데 실패했어요.')
+      router.back()
+    })
+  }, [fetchChatMessages, nbreadId, router])
 
   useEffect(() => {
-    if (scrollState) {
-      bottomRef.current?.scrollIntoView({ block: 'end' })
-      setScrollState(false)
+    if (!nbreadId) {
+      return
     }
-  }, [chatMessages])
 
-  const scrollToBottom = () => {
-    const container = scrollContainerRef.current
-    if (container) {
-      container.scrollTop = container.scrollHeight
-    }
-  }
-
-  useEffect(() => {
-    if (scrollState) {
-      scrollToBottom()
-      setScrollState(false)
-    }
-  }, [chatMessages])
-
-  const subscribeChatRoom = async () => {
     const channel = supabase
-      .channel(`${nbreadId}`)
+      .channel(nbreadId)
       .on(
         'postgres_changes',
         {
@@ -82,13 +148,14 @@ const ChatRoom = () => {
           const newChatMessage: ChatMessage = {
             id: payload.new.id,
             content: payload.new.content,
-            userId: payload.new.user_id,
+            userId: payload.new.user_id ?? '',
             userName: payload.new.user_name,
             userProfileImage: payload.new.user_profile_image,
             nbreadId: payload.new.nbread_id,
             createdAt: payload.new.created_at,
           }
-          setChatMessages((prev) => [...prev, newChatMessage])
+
+          setChatMessages((prev) => mergeIncomingMessage(prev, newChatMessage))
         },
       )
       .subscribe()
@@ -96,50 +163,22 @@ const ChatRoom = () => {
     return () => {
       supabase.removeChannel(channel)
     }
-  }
-
-  useEffect(() => {
-    if (!params.nbreadId) {
-      useToast.error('잘못된 URL 주소입니다. 다시 시도해주세요.')
-      router.back()
-      return
-    }
-
-    try {
-      const nbreadId = params.nbreadId as string
-      setNbreadId(nbreadId)
-      fetchChatMessages(nbreadId)
-    } catch (error) {
-      useToast.error('메시지 내역을 불러오는 데 실패했어요.')
-      router.back()
-    }
-  }, [])
-
-  useEffect(() => {
-    subscribeChatRoom()
   }, [nbreadId])
 
-  // ✅ 사용자+분 단위 그룹 중 마지막 메시지인지 판단
-  const isLastInMinuteGroup = (index: number) => {
-    const current = chatMessages[index]
-    const next = chatMessages[index + 1]
+  useEffect(() => {
+    const animationFrameId = requestAnimationFrame(() => {
+      bottomRef.current?.scrollIntoView({ block: 'end' })
 
-    const formatTime = (date: string) =>
-      new Date(date).toLocaleString('ko-KR', {
-        timeZone: 'Asia/Seoul',
-        hour: '2-digit',
-        minute: '2-digit',
-      })
+      const container = scrollContainerRef.current
+      if (container) {
+        container.scrollTop = container.scrollHeight
+      }
+    })
 
-    const currentTime = formatTime(current.createdAt)
-    const nextTime = next ? formatTime(next.createdAt) : null
-
-    if (next && next.userId === current.userId && nextTime === currentTime) {
-      return false
+    return () => {
+      cancelAnimationFrame(animationFrameId)
     }
-
-    return true
-  }
+  }, [chatMessages.length])
 
   if (!hasFetched) {
     return <Spinner isLoading={true} />
@@ -151,57 +190,9 @@ const ChatRoom = () => {
       className="mt-4 h-screen w-full overflow-y-auto px-24"
     >
       <div className="flex w-full flex-col justify-between">
-        {chatMessages.length === 0 ? (
-          <div>아직 메시지가 없어요.</div>
-        ) : (
-          chatMessages.map((chatMessage, index) =>
-            chatMessage.userId === user?.id ? (
-              <div key={index} className="flex flex-row justify-end">
-                <div className="mb-4 flex items-end text-body03 text-gray-400">
-                  {isLastInMinuteGroup(index) &&
-                    new Date(chatMessage.createdAt).toLocaleString('ko-KR', {
-                      timeZone: 'Asia/Seoul',
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    })}
-                </div>
-                <div className="mb-4 ml-8 flex items-center rounded-16 border border-gray-100 bg-primary-500 px-16 py-12 text-body02">
-                  {chatMessage.content}
-                </div>
-              </div>
-            ) : (
-              <div key={index}>
-                {index === 0 ||
-                chatMessages[index - 1].userId !==
-                  chatMessages[index].userId ? (
-                  <div className="flex flex-row items-center justify-start gap-12">
-                    <Avatar
-                      size="small"
-                      profileImageUrl={chatMessage.userProfileImage}
-                    />
-                    <div className="text-body02">{chatMessage.userName}</div>
-                  </div>
-                ) : null}
-                <div className="ml-32 flex flex-row">
-                  <div className="shadow-avatar mb-4 mr-8 rounded-16 border-gray-100 bg-white px-16 py-12 text-body02">
-                    {chatMessage.content}
-                  </div>
-                  <div className="mb-4 flex items-end text-body03 text-gray-400">
-                    {isLastInMinuteGroup(index) &&
-                      new Date(chatMessage.createdAt).toLocaleString('ko-KR', {
-                        timeZone: 'Asia/Seoul',
-                        hour: '2-digit',
-                        minute: '2-digit',
-                      })}
-                  </div>
-                </div>
-              </div>
-            ),
-          )
-        )}
+        <MessageList messages={chatMessages} currentUserId={user?.id} />
         <div ref={bottomRef}></div>
       </div>
-      {/* 채팅 메시지 하단 여백 추가 (input에 가려지지 않도록) */}
       <div className="h-92" />
 
       <div className="absolute bottom-0 left-0 h-80 w-full bg-gray-50">
@@ -211,8 +202,13 @@ const ChatRoom = () => {
           type="text"
           value={inputText}
           onChange={(event) => setInputText(event.target.value)}
-          onKeyPress={(event) => {
+          onKeyDown={(event) => {
+            if (event.nativeEvent.isComposing) {
+              return
+            }
+
             if (event.key === 'Enter' && inputText.trim() !== '') {
+              event.preventDefault()
               sendChatMessages(inputText)
               setInputText('')
             }

--- a/src/components/chat/ChatRoom.tsx
+++ b/src/components/chat/ChatRoom.tsx
@@ -6,6 +6,7 @@ import { insertChatMessage } from '@/lib/chatMessage/insertChatMessage'
 import { supabase } from '@/lib/supabaseClient'
 import useUserStore from '@/stores/useAuthStore'
 import { ChatMessage } from '@/types/chatMessage'
+import { formatChatMessageTime } from '@/utils/formatChatMessageTime'
 import { useParams, useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Spinner from '../common/spinner/Spinner'
@@ -84,6 +85,7 @@ const ChatRoom = () => {
       }
 
       const tempId = `temp-${Date.now()}`
+      const createdAt = new Date().toISOString()
       const optimisticMessage: ChatMessage = {
         id: tempId,
         content,
@@ -91,7 +93,8 @@ const ChatRoom = () => {
         userName: user.name,
         userProfileImage: user.profileImage,
         nbreadId,
-        createdAt: new Date().toISOString(),
+        createdAt,
+        formattedTime: formatChatMessageTime(createdAt),
         status: 'sending',
       }
 
@@ -153,6 +156,7 @@ const ChatRoom = () => {
             userProfileImage: payload.new.user_profile_image,
             nbreadId: payload.new.nbread_id,
             createdAt: payload.new.created_at,
+            formattedTime: formatChatMessageTime(payload.new.created_at),
           }
 
           setChatMessages((prev) => mergeIncomingMessage(prev, newChatMessage))

--- a/src/components/chat/MessageItem.tsx
+++ b/src/components/chat/MessageItem.tsx
@@ -1,0 +1,65 @@
+import Avatar from '@/components/common/avatar/avatar'
+import { memo } from 'react'
+
+interface MessageItemProps {
+  content: string
+  formattedTime: string
+  isMine: boolean
+  showSender: boolean
+  showTime: boolean
+  status?: 'sending' | 'failed'
+  userName: string
+  userProfileImage: string | null
+}
+
+const MessageItem = ({
+  content,
+  formattedTime,
+  isMine,
+  showSender,
+  showTime,
+  status,
+  userName,
+  userProfileImage,
+}: MessageItemProps) => {
+  if (isMine) {
+    return (
+      <div className="flex flex-row justify-end">
+        <div className="mb-4 flex items-end text-body03 text-gray-400">
+          {showTime && formattedTime}
+        </div>
+        <div
+          className={`mb-4 ml-8 flex items-center rounded-16 border border-gray-100 bg-primary-500 px-16 py-12 text-body02 ${
+            status === 'failed' ? 'opacity-60' : ''
+          }`}
+        >
+          {content}
+          {status === 'failed' && (
+            <span className="ml-8 text-body03 text-gray-500">실패</span>
+          )}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {showSender && (
+        <div className="flex flex-row items-center justify-start gap-12">
+          <Avatar size="small" profileImageUrl={userProfileImage} />
+          <div className="text-body02">{userName}</div>
+        </div>
+      )}
+      <div className="ml-32 flex flex-row">
+        <div className="shadow-avatar mb-4 mr-8 rounded-16 border-gray-100 bg-white px-16 py-12 text-body02">
+          {content}
+        </div>
+        <div className="mb-4 flex items-end text-body03 text-gray-400">
+          {showTime && formattedTime}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default memo(MessageItem)

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,0 +1,65 @@
+import { ChatMessage } from '@/types/chatMessage'
+import { memo, useMemo } from 'react'
+import MessageItem from './MessageItem'
+
+interface MessageListProps {
+  messages: ChatMessage[]
+  currentUserId?: string
+}
+
+const formatMessageTime = (createdAt: string) =>
+  new Date(createdAt).toLocaleString('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+
+const MessageList = ({ messages, currentUserId }: MessageListProps) => {
+  const messageItems = useMemo(
+    () =>
+      messages.map((message, index) => {
+        const previous = messages[index - 1]
+        const next = messages[index + 1]
+        const formattedTime = formatMessageTime(message.createdAt)
+        const nextFormattedTime = next
+          ? formatMessageTime(next.createdAt)
+          : null
+
+        return {
+          ...message,
+          formattedTime,
+          isMine: message.userId === currentUserId,
+          showSender: !previous || previous.userId !== message.userId,
+          showTime:
+            !next ||
+            next.userId !== message.userId ||
+            nextFormattedTime !== formattedTime,
+        }
+      }),
+    [currentUserId, messages],
+  )
+
+  if (messageItems.length === 0) {
+    return <div>아직 메시지가 없어요.</div>
+  }
+
+  return (
+    <>
+      {messageItems.map((message) => (
+        <MessageItem
+          key={message.id}
+          content={message.content}
+          formattedTime={message.formattedTime}
+          isMine={message.isMine}
+          showSender={message.showSender}
+          showTime={message.showTime}
+          status={message.status}
+          userName={message.userName}
+          userProfileImage={message.userProfileImage}
+        />
+      ))}
+    </>
+  )
+}
+
+export default memo(MessageList)

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -1,5 +1,5 @@
 import { ChatMessage } from '@/types/chatMessage'
-import { memo, useMemo } from 'react'
+import { memo } from 'react'
 import MessageItem from './MessageItem'
 
 interface MessageListProps {
@@ -7,57 +7,35 @@ interface MessageListProps {
   currentUserId?: string
 }
 
-const formatMessageTime = (createdAt: string) =>
-  new Date(createdAt).toLocaleString('ko-KR', {
-    timeZone: 'Asia/Seoul',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-
 const MessageList = ({ messages, currentUserId }: MessageListProps) => {
-  const messageItems = useMemo(
-    () =>
-      messages.map((message, index) => {
-        const previous = messages[index - 1]
-        const next = messages[index + 1]
-        const formattedTime = formatMessageTime(message.createdAt)
-        const nextFormattedTime = next
-          ? formatMessageTime(next.createdAt)
-          : null
-
-        return {
-          ...message,
-          formattedTime,
-          isMine: message.userId === currentUserId,
-          showSender: !previous || previous.userId !== message.userId,
-          showTime:
-            !next ||
-            next.userId !== message.userId ||
-            nextFormattedTime !== formattedTime,
-        }
-      }),
-    [currentUserId, messages],
-  )
-
-  if (messageItems.length === 0) {
+  if (messages.length === 0) {
     return <div>아직 메시지가 없어요.</div>
   }
 
   return (
     <>
-      {messageItems.map((message) => (
-        <MessageItem
-          key={message.id}
-          content={message.content}
-          formattedTime={message.formattedTime}
-          isMine={message.isMine}
-          showSender={message.showSender}
-          showTime={message.showTime}
-          status={message.status}
-          userName={message.userName}
-          userProfileImage={message.userProfileImage}
-        />
-      ))}
+      {messages.map((message, index) => {
+        const previous = messages[index - 1]
+        const next = messages[index + 1]
+        const showTime =
+          !next ||
+          next.userId !== message.userId ||
+          next.formattedTime !== message.formattedTime
+
+        return (
+          <MessageItem
+            key={message.id}
+            content={message.content}
+            formattedTime={message.formattedTime}
+            isMine={message.userId === currentUserId}
+            showSender={!previous || previous.userId !== message.userId}
+            showTime={showTime}
+            status={message.status}
+            userName={message.userName}
+            userProfileImage={message.userProfileImage}
+          />
+        )
+      })}
     </>
   )
 }

--- a/src/lib/chatMessage/getChatMessages.tsx
+++ b/src/lib/chatMessage/getChatMessages.tsx
@@ -15,11 +15,11 @@ export const getChatMessages = async (nbreadId: string) => {
     }
 
     // 불러온 row data를 ChatMessage 타입으로 매핑
-    const chatMessages: ChatMessage[] = data.map((item, index) => ({
+    const chatMessages: ChatMessage[] = data.map((item) => ({
       id: item.id,
       content: item.content,
       nbreadId: item.nbread_id,
-      userId: item.user_id,
+      userId: item.user_id ?? '',
       userName: item.user_name,
       userProfileImage: item.user_profile_image,
       createdAt: item.created_at,

--- a/src/lib/chatMessage/getChatMessages.tsx
+++ b/src/lib/chatMessage/getChatMessages.tsx
@@ -1,5 +1,6 @@
 import { supabase } from '@/lib/supabaseClient'
 import { ChatMessage } from '@/types/chatMessage'
+import { formatChatMessageTime } from '@/utils/formatChatMessageTime'
 
 /* getChatMessages: DB로부터 그룹 메시지 내역을 불러옴 */
 export const getChatMessages = async (nbreadId: string) => {
@@ -23,6 +24,7 @@ export const getChatMessages = async (nbreadId: string) => {
       userName: item.user_name,
       userProfileImage: item.user_profile_image,
       createdAt: item.created_at,
+      formattedTime: formatChatMessageTime(item.created_at),
     }))
 
     return chatMessages

--- a/src/lib/chatMessage/insertChatMessage.tsx
+++ b/src/lib/chatMessage/insertChatMessage.tsx
@@ -1,6 +1,7 @@
 import { supabase } from '@/lib/supabaseClient'
 import { ChatMessage } from '@/types/chatMessage'
 import { User } from '@/types/user'
+import { formatChatMessageTime } from '@/utils/formatChatMessageTime'
 
 export const insertChatMessage = async (
   user: User,
@@ -33,6 +34,7 @@ export const insertChatMessage = async (
       userName: data.user_name,
       userProfileImage: data.user_profile_image,
       createdAt: data.created_at,
+      formattedTime: formatChatMessageTime(data.created_at),
     }
   } catch (error) {
     throw error

--- a/src/lib/chatMessage/insertChatMessage.tsx
+++ b/src/lib/chatMessage/insertChatMessage.tsx
@@ -1,11 +1,12 @@
 import { supabase } from '@/lib/supabaseClient'
+import { ChatMessage } from '@/types/chatMessage'
 import { User } from '@/types/user'
 
 export const insertChatMessage = async (
   user: User,
   nbreadId: string,
   content: string,
-) => {
+): Promise<ChatMessage> => {
   try {
     const { data, error } = await supabase
       .from('chat_messages')
@@ -16,15 +17,23 @@ export const insertChatMessage = async (
         user_profile_image: user.profileImage,
         content: content,
       })
-      .select('id')
+      .select('*')
       .single()
 
-    if (error) {
+    if (error || !data) {
       console.error('Error inserting chat messages:', error)
       throw error
     }
 
-    return data.id
+    return {
+      id: data.id,
+      content: data.content,
+      nbreadId: data.nbread_id,
+      userId: data.user_id ?? '',
+      userName: data.user_name,
+      userProfileImage: data.user_profile_image,
+      createdAt: data.created_at,
+    }
   } catch (error) {
     throw error
   }

--- a/src/types/chatMessage.ts
+++ b/src/types/chatMessage.ts
@@ -4,6 +4,7 @@ export interface ChatMessage {
   nbreadId: string
   userId: string
   userName: string
-  userProfileImage: string
+  userProfileImage: string | null
   createdAt: string
+  status?: 'sending' | 'failed'
 }

--- a/src/types/chatMessage.ts
+++ b/src/types/chatMessage.ts
@@ -6,5 +6,6 @@ export interface ChatMessage {
   userName: string
   userProfileImage: string | null
   createdAt: string
+  formattedTime: string
   status?: 'sending' | 'failed'
 }

--- a/src/utils/formatChatMessageTime.ts
+++ b/src/utils/formatChatMessageTime.ts
@@ -1,0 +1,6 @@
+export const formatChatMessageTime = (createdAt: string) =>
+  new Date(createdAt).toLocaleString('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    hour: '2-digit',
+    minute: '2-digit',
+  })


### PR DESCRIPTION
## #️⃣연관된 이슈

#52

## 📝작업 내용

- 채팅 메시지 렌더링 로직을 MessageList, MessageItem으로 분리하고 MessageItem에 memo를 적용했습니다.
- 메시지 전송 시 낙관적 업데이트를 적용하고 Realtime 수신 중복 방지 로직을 추가했습니다.
- 메시지 시간 포맷을 생성/조회 시점에 미리 계산해 MessageList 렌더링 중 반복 계산을 줄였습니다.
- 한글 IME 입력 중 Enter 전송으로 마지막 글자가 중복 전송되는 문제를 방지했습니다.

### 스크린샷 (선택)

없음

## 💬리뷰 요구사항(선택)

X

## ✅검증

X