### PR TITLE
[fix-50/delete-account] 회원 탈퇴 오류 수정

### DIFF
--- a/src/app/api/auth/delete-account/route.ts
+++ b/src/app/api/auth/delete-account/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+import { captureAppError } from '@/lib/sentry/sentry'
+
+export const runtime = 'nodejs'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabasePublishableKey =
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ??
+  process.env.NEXT_PUBLIC_SUPABASE_KEY
+const supabaseSecretKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SECRET_KEY
+
+const authSupabase =
+  supabaseUrl && supabasePublishableKey
+    ? createClient(supabaseUrl, supabasePublishableKey, {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false,
+          detectSessionInUrl: false,
+        },
+      })
+    : null
+
+const adminSupabase =
+  supabaseUrl && supabaseSecretKey
+    ? createClient(supabaseUrl, supabaseSecretKey, {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false,
+          detectSessionInUrl: false,
+        },
+      })
+    : null
+
+export async function POST(request: Request) {
+  if (!authSupabase || !adminSupabase) {
+    return NextResponse.json(
+      { message: 'Supabase 서버 환경 변수가 설정되지 않았습니다.' },
+      { status: 500 },
+    )
+  }
+
+  const authorization = request.headers.get('authorization')
+  const accessToken = authorization?.startsWith('Bearer ')
+    ? authorization.slice('Bearer '.length)
+    : null
+
+  if (!accessToken) {
+    return NextResponse.json(
+      { message: '인증 토큰이 없습니다.' },
+      { status: 401 },
+    )
+  }
+
+  const {
+    data: { user },
+    error: userError,
+  } = await authSupabase.auth.getUser(accessToken)
+
+  if (userError || !user) {
+    return NextResponse.json(
+      { message: '유효하지 않은 인증 토큰입니다.' },
+      { status: 401 },
+    )
+  }
+
+  const { error: deleteError } = await adminSupabase.auth.admin.deleteUser(
+    user.id,
+  )
+
+  if (deleteError) {
+    captureAppError(deleteError, {
+      action: 'auth.delete_account.api',
+      tags: { userId: user.id },
+    })
+
+    return NextResponse.json(
+      { message: '회원 탈퇴에 실패했습니다.' },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/components/mypage/Manage.tsx
+++ b/src/components/mypage/Manage.tsx
@@ -2,7 +2,7 @@ import { logout } from '@/lib/auth'
 import { useRouter } from 'next/navigation'
 import LogoutModal from '../user/LogoutModal'
 import DeleteAccountModal from '../user/DeleteAccountModal'
-import { Dispatch, RefObject, SetStateAction, useState } from 'react'
+import { Dispatch, SetStateAction, useState } from 'react'
 import { deleteAccount } from '@/lib/auth'
 
 interface ManageProps {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,5 @@
 import { supabase } from './supabaseClient'
-import { adminSupabase } from './supabaseAdminClient'
-import { LoginProvider, User } from '@/types/user'
+import { LoginProvider } from '@/types/user'
 import useUserStore from '@/stores/useAuthStore'
 import { useRouter } from 'next/navigation'
 import { useToast } from '@/components/common/toast/Toast'
@@ -58,24 +57,37 @@ export const logout = async (router: ReturnType<typeof useRouter>) => {
 
 // 3. 계정 탈퇴 함수
 export const deleteAccount = async (router: ReturnType<typeof useRouter>) => {
-  const data = await supabase.auth.getUser()
-  const user = data.data.user?.id
-  if (!user) {
-    const error = new Error('유저정보를 찾을수 없음')
+  const { data, error: sessionError } = await supabase.auth.getSession()
+  const accessToken = data.session?.access_token
+
+  if (sessionError || !accessToken) {
+    const error = sessionError ?? new Error('유저정보를 찾을수 없음')
     captureAppError(error, {
       action: 'auth.delete_account',
     })
     throw error
   }
-  const { error } = await adminSupabase.auth.admin.deleteUser(user)
-  if (error) {
+
+  const response = await fetch('/api/auth/delete-account', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+
+  if (!response.ok) {
+    const result = (await response.json().catch(() => null)) as {
+      message?: string
+    } | null
+    const error = new Error(result?.message ?? '회원 탈퇴에 실패했습니다.')
     captureAppError(error, {
       action: 'auth.delete_account',
-      tags: { userId: user },
+      tags: { status: response.status },
     })
     throw error
   }
-  await supabase.auth.signOut()
+
+  await supabase.auth.signOut({ scope: 'local' })
   useUserStore.getState().clearUser()
   sessionStorage.removeItem('user-store')
   localStorage.clear()
@@ -107,7 +119,7 @@ export const getUserName = async (leaderId: string) => {
 
     // 사용자 이름 반환
     return data.name
-  } catch (error) {
+  } catch {
     return null // 에러 발생 시 null 반환
   }
 }

--- a/src/lib/supabaseAdminClient.ts
+++ b/src/lib/supabaseAdminClient.ts
@@ -1,10 +1,18 @@
+import 'server-only'
 import { createClient } from '@supabase/supabase-js'
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
-const supabasePublishableKey = process.env
-  .NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY as string
 
-if (!supabaseUrl || !supabasePublishableKey) {
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
+const supabaseSecretKey = (process.env.SUPABASE_SERVICE_ROLE_KEY ??
+  process.env.SUPABASE_SECRET_KEY) as string
+
+if (!supabaseUrl || !supabaseSecretKey) {
   console.error('환경 변수가 올바르게 설정되지 않았습니다.')
 }
 
-export const adminSupabase = createClient(supabaseUrl, supabasePublishableKey)
+export const adminSupabase = createClient(supabaseUrl, supabaseSecretKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+    detectSessionInUrl: false,
+  },
+})


### PR DESCRIPTION
## #️⃣연관된 이슈

#50

## 📝작업 내용

### 회원 탈퇴 API 분리
- 클라이언트에서 Supabase Admin API를 직접 호출하지 않도록 서버 API 라우트를 추가했습니다.
- 서버에서 Bearer token으로 사용자 본인을 검증한 뒤 service role key로 계정을 삭제하도록 변경했습니다.

### 인증 세션 정리
- 탈퇴 성공 후 로컬 세션만 정리하도록 변경해 삭제된 계정의 global logout 403 로그를 방지했습니다.
- admin Supabase client를 서버 전용 secret key 기반으로 수정했습니다.

### 스크린샷 (선택)

X

## 💬리뷰 요구사항(선택)

X