### PR TITLE
[feature-51/terms-accept] 약관 동의 기능 구현

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -16,6 +16,7 @@ module.exports = {
     '/mypage/*',
     '/nbread/*',
     '/notification',
+    '/terms-agreement',
   ],
   robotsTxtOptions: {
     policies: [
@@ -33,6 +34,7 @@ module.exports = {
           '/mypage',
           '/nbread/',
           '/notification',
+          '/terms-agreement',
         ],
       },
     ],

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -11,6 +11,7 @@ Disallow: /inviteAccept
 Disallow: /mypage
 Disallow: /nbread/
 Disallow: /notification
+Disallow: /terms-agreement
 
 # Host
 Host: https://nbread-nbread.vercel.app

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://nbread-nbread.vercel.app</loc><lastmod>2026-05-21T08:29:24.259Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://nbread-nbread.vercel.app/login</loc><lastmod>2026-05-21T08:29:24.259Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://nbread-nbread.vercel.app/ios-guide</loc><lastmod>2026-05-21T08:29:24.259Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://nbread-nbread.vercel.app/ios-guide</loc><lastmod>2026-06-04T11:49:35.254Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://nbread-nbread.vercel.app/terms-of-service</loc><lastmod>2026-06-04T11:49:35.257Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://nbread-nbread.vercel.app</loc><lastmod>2026-06-04T11:49:35.257Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://nbread-nbread.vercel.app/privacy-policy</loc><lastmod>2026-06-04T11:49:35.257Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://nbread-nbread.vercel.app/login</loc><lastmod>2026-06-04T11:49:35.257Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,66 +1,19 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabaseClient'
-import useUserStore from '@/stores/useAuthStore'
-import { useRouter } from 'next/navigation'
-import NProgress from 'nprogress'
 import 'nprogress/nprogress.css'
 import Spinner from '@/components/common/spinner/Spinner'
-import { GA_EVENTS, trackEvent } from '@/lib/analytics/events'
-
-// NProgress 스피너 비활성화
-NProgress.configure({ showSpinner: false })
+import { useAuthCallbackFlow } from '@/hooks/useAuthCallbackFlow'
 
 const CallbackPage = () => {
-  const [loading, setLoading] = useState(true)
-  const setUser = useUserStore((state) => state.setUser)
-  const router = useRouter()
+  const { loading, errorMessage } = useAuthCallbackFlow()
 
-  useEffect(() => {
-    const fetchUserData = async () => {
-      try {
-        NProgress.start() // 로딩 시작
-
-        const { data, error } = await supabase.auth.getUser()
-
-        if (error) {
-          console.error('Error fetching user data:', error.message)
-          return
-        }
-
-        if (data.user) {
-          const getUserInfo = await supabase
-            .from('user')
-            .select('*')
-            .eq('id', data.user.id)
-          const provider = data.user.app_metadata.provider as 'kakao' | 'google'
-
-          const userInfo = {
-            id: data.user.id,
-            email: data.user.email || '',
-            socialType: provider,
-            name: data.user.user_metadata.full_name || '',
-            profileImage: data.user.user_metadata.avatar_url || '',
-            tag: getUserInfo.data?.[0]?.tag || '',
-          }
-          setUser(userInfo) // 사용자 정보 세션 스토리지에 저장
-          trackEvent(GA_EVENTS.SIGN_IN, { provider })
-          setTimeout(() => {
-            setLoading(false)
-            localStorage.clear()
-            router.replace('/')
-          }, 1000)
-        }
-      } catch (error) {
-        console.error('Error fetching user data:', error)
-      } finally {
-        NProgress.done() // 로딩 완료
-      }
-    }
-
-    fetchUserData()
-  }, [router, setUser])
+  if (errorMessage) {
+    return (
+      <main className="flex min-h-dvh items-center justify-center bg-background px-24">
+        <p className="text-center text-body02 text-gray-600">{errorMessage}</p>
+      </main>
+    )
+  }
 
   return <Spinner isLoading={loading} />
 }

--- a/src/app/protectRoute.tsx
+++ b/src/app/protectRoute.tsx
@@ -5,8 +5,22 @@ import { usePathname, useRouter } from 'next/navigation'
 import LoginConfirmModal from '@/components/common/modal/LoginConfirmModal'
 import { setSentryUser } from '@/lib/sentry/sentry'
 import useUserStore from '@/stores/useAuthStore'
+import {
+  getCurrentUserRow,
+  hasRequiredTermsAgreement,
+} from '@/lib/termsAgreement'
 
-const publicRoutes = ['/login', '/auth/callback', '/inviteAccept']
+const publicRoutes = [
+  '/login',
+  '/auth/callback',
+  '/inviteAccept',
+  '/terms-agreement',
+]
+const termsAgreementExemptRoutes = [
+  ...publicRoutes,
+  '/terms-of-service',
+  '/privacy-policy',
+]
 
 export default function ProtectRoute({
   children,
@@ -30,6 +44,24 @@ export default function ProtectRoute({
       setIsProtectedRoute(true)
     }
   }, [pathname])
+
+  useEffect(() => {
+    if (!user?.id || termsAgreementExemptRoutes.includes(pathname)) return
+
+    const redirectIfRequiredTermsNotAgreed = async () => {
+      try {
+        const userRow = await getCurrentUserRow(user.id)
+
+        if (userRow && !hasRequiredTermsAgreement(userRow)) {
+          router.replace('/terms-agreement')
+        }
+      } catch (error) {
+        console.error('Error checking required terms agreement:', error)
+      }
+    }
+
+    redirectIfRequiredTermsNotAgreed()
+  }, [pathname, router, user?.id])
 
   return (
     <div className="min-h-[100svh]">

--- a/src/app/terms-agreement/page.tsx
+++ b/src/app/terms-agreement/page.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import DetailHeader from '@/components/common/header/DetailHeader'
+import Spinner from '@/components/common/spinner/Spinner'
+import TermsAgreementExitModal from '@/components/user/TermsAgreementExitModal'
+import TermsAgreementForm from '@/components/user/TermsAgreementForm'
+import { useTermsAgreementPage } from '@/hooks/useTermsAgreementPage'
+
+const TermsAgreementPage = () => {
+  const {
+    isLoading,
+    isSubmitting,
+    termsChecked,
+    privacyChecked,
+    isAllChecked,
+    isExitModalOpen,
+    setTermsChecked,
+    setPrivacyChecked,
+    setIsExitModalOpen,
+    toggleAll,
+    submitAgreement,
+    logoutAndGoLogin,
+  } = useTermsAgreementPage()
+
+  return (
+    <main className="flex min-h-dvh flex-col bg-background">
+      <div className="px-24 pt-16">
+        <DetailHeader onClickBack={() => setIsExitModalOpen(true)} />
+      </div>
+      {isLoading ? (
+        <Spinner isLoading={isLoading} />
+      ) : (
+        <TermsAgreementForm
+          termsChecked={termsChecked}
+          privacyChecked={privacyChecked}
+          isAllChecked={isAllChecked}
+          isSubmitting={isSubmitting}
+          onToggleAll={toggleAll}
+          onToggleTerms={() => setTermsChecked((checked) => !checked)}
+          onTogglePrivacy={() => setPrivacyChecked((checked) => !checked)}
+          onSubmit={submitAgreement}
+          onLater={() => setIsExitModalOpen(true)}
+        />
+      )}
+      <TermsAgreementExitModal
+        isOpen={isExitModalOpen}
+        onClose={() => setIsExitModalOpen(false)}
+        onSubmit={logoutAndGoLogin}
+      />
+    </main>
+  )
+}
+
+export default TermsAgreementPage

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -6,6 +6,7 @@ import { FOOTER_LINKS } from '@/constants/footerLinks'
 
 const HIDE_FOOTER_PATTERNS: RegExp[] = [
   /^\/nbread\/[^/]+$/, // 채팅/게시판 탭이 포함된 엔빵 상세 페이지
+  /^\/terms-agreement$/,
 ]
 
 const Footer = () => {

--- a/src/components/user/TermsAgreementExitModal.tsx
+++ b/src/components/user/TermsAgreementExitModal.tsx
@@ -1,0 +1,44 @@
+import Modal from '@/components/common/modal/Modal'
+
+interface TermsAgreementExitModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onSubmit: () => void
+}
+
+const TermsAgreementExitModal = ({
+  isOpen,
+  onClose,
+  onSubmit,
+}: TermsAgreementExitModalProps) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <div className="flex flex-col p-8">
+        <div className="mb-24 flex flex-col gap-12 pl-8">
+          <div className="text-heading05 text-gray-800">
+            약관에 동의해주세요.
+          </div>
+          <div className="whitespace-pre-line text-body02 text-gray-800">
+            {`약관에 동의하지 않으면\n서비스를 사용할 수 없어요.`}
+          </div>
+        </div>
+        <div className="flex flex-row gap-8">
+          <button
+            onClick={onSubmit}
+            className="btn h-48 flex-1 rounded-8 bg-gray-200 text-heading05 text-gray-700"
+          >
+            나중에 하기
+          </button>
+          <button
+            onClick={onClose}
+            className="btn h-48 flex-1 rounded-8 bg-secondary-100 text-heading05 text-white"
+          >
+            동의하기
+          </button>
+        </div>
+      </div>
+    </Modal>
+  )
+}
+
+export default TermsAgreementExitModal

--- a/src/components/user/TermsAgreementForm.tsx
+++ b/src/components/user/TermsAgreementForm.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import Link from 'next/link'
+import Checkbox from '@/components/common/checkbox/checkbox'
+
+interface TermsAgreementFormProps {
+  termsChecked: boolean
+  privacyChecked: boolean
+  isAllChecked: boolean
+  isSubmitting: boolean
+  onToggleAll: () => void
+  onToggleTerms: () => void
+  onTogglePrivacy: () => void
+  onSubmit: () => void
+  onLater: () => void
+}
+
+const TermsAgreementForm = ({
+  termsChecked,
+  privacyChecked,
+  isAllChecked,
+  isSubmitting,
+  onToggleAll,
+  onToggleTerms,
+  onTogglePrivacy,
+  onSubmit,
+  onLater,
+}: TermsAgreementFormProps) => {
+  return (
+    <section className="flex flex-1 flex-col px-24 pb-32 pt-24">
+      <h1 className="whitespace-pre-line pb-8 text-heading01 text-gray-800">
+        {`엔빵을 사용하기 위해`}
+      </h1>
+      <h1 className="whitespace-pre-line text-heading01 text-gray-800">
+        {`약관 동의가 필요해요`}
+      </h1>
+
+      <div className="mt-64 flex flex-col gap-20">
+        <div className="flex items-center gap-16 text-body01 text-gray-800">
+          <Checkbox isChecked={isAllChecked} onChange={onToggleAll} />
+          <button type="button" onClick={onToggleAll}>
+            약관 전체 동의
+          </button>
+        </div>
+
+        <div className="flex items-center gap-16 text-body01 text-gray-500">
+          <Checkbox isChecked={termsChecked} onChange={onToggleTerms} />
+          <Link href="/terms-of-service" className="underline">
+            (필수) 서비스 이용 약관 동의
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-16 text-body01 text-gray-500">
+          <Checkbox isChecked={privacyChecked} onChange={onTogglePrivacy} />
+          <Link href="/privacy-policy" className="underline">
+            (필수) 개인정보 처리방침 동의
+          </Link>
+        </div>
+      </div>
+
+      <div className="mt-auto flex flex-col items-center gap-22">
+        <button
+          type="button"
+          disabled={!isAllChecked || isSubmitting}
+          onClick={onSubmit}
+          className={`btn btn-large ${
+            isAllChecked && !isSubmitting ? 'btn-primary' : 'btn-disabled'
+          }`}
+        >
+          확인
+        </button>
+        <button
+          type="button"
+          onClick={onLater}
+          className="text-body02 text-gray-400"
+        >
+          나중에 하기
+        </button>
+      </div>
+    </section>
+  )
+}
+
+export default TermsAgreementForm

--- a/src/hooks/useAuthCallbackFlow.ts
+++ b/src/hooks/useAuthCallbackFlow.ts
@@ -1,0 +1,70 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import NProgress from 'nprogress'
+import { supabase } from '@/lib/supabaseClient'
+import { GA_EVENTS, trackEvent } from '@/lib/analytics/events'
+import useUserStore from '@/stores/useAuthStore'
+import {
+  getCurrentUserRow,
+  hasRequiredTermsAgreement,
+  toUserStoreValue,
+} from '@/lib/termsAgreement'
+
+NProgress.configure({ showSpinner: false })
+
+export const useAuthCallbackFlow = () => {
+  const [loading, setLoading] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const setUser = useUserStore((state) => state.setUser)
+  const router = useRouter()
+
+  useEffect(() => {
+    const handleAuthCallback = async () => {
+      try {
+        NProgress.start()
+
+        const { data, error } = await supabase.auth.getUser()
+
+        if (error || !data.user) {
+          throw error ?? new Error('로그인 정보를 찾을 수 없습니다.')
+        }
+
+        const userRow = await getCurrentUserRow(data.user.id)
+
+        if (!userRow) {
+          throw new Error(
+            '사용자 정보를 찾을 수 없습니다. 다시 로그인해주세요.',
+          )
+        }
+
+        const userInfo = toUserStoreValue(data.user, userRow)
+        setUser(userInfo)
+        trackEvent(GA_EVENTS.SIGN_IN, { provider: userInfo.socialType })
+        localStorage.clear()
+
+        if (hasRequiredTermsAgreement(userRow)) {
+          router.replace('/')
+          return
+        }
+
+        router.replace('/terms-agreement')
+      } catch (error) {
+        console.error('Error handling auth callback:', error)
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : '로그인 처리 중 문제가 발생했습니다.',
+        )
+      } finally {
+        setLoading(false)
+        NProgress.done()
+      }
+    }
+
+    handleAuthCallback()
+  }, [router, setUser])
+
+  return { loading, errorMessage }
+}

--- a/src/hooks/useTermsAgreementPage.ts
+++ b/src/hooks/useTermsAgreementPage.ts
@@ -1,0 +1,110 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
+import { useToast } from '@/components/common/toast/Toast'
+import useUserStore from '@/stores/useAuthStore'
+import {
+  agreeRequiredTerms,
+  getCurrentUserRow,
+  hasRequiredTermsAgreement,
+  toUserStoreValue,
+} from '@/lib/termsAgreement'
+
+export const useTermsAgreementPage = () => {
+  const router = useRouter()
+  const setUser = useUserStore((state) => state.setUser)
+  const clearUser = useUserStore((state) => state.clearUser)
+  const storeUser = useUserStore((state) => state.user)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [termsChecked, setTermsChecked] = useState(false)
+  const [privacyChecked, setPrivacyChecked] = useState(false)
+  const [isExitModalOpen, setIsExitModalOpen] = useState(false)
+
+  const isAllChecked = termsChecked && privacyChecked
+
+  useEffect(() => {
+    const checkAgreementState = async () => {
+      try {
+        const { data, error } = await supabase.auth.getUser()
+
+        if (error || !data.user) {
+          router.replace('/login')
+          return
+        }
+
+        const userRow = await getCurrentUserRow(data.user.id)
+
+        if (!userRow) {
+          useToast.error('사용자 정보를 찾을 수 없어요. 다시 로그인해주세요.')
+          router.replace('/login')
+          return
+        }
+
+        if (!storeUser) {
+          setUser(toUserStoreValue(data.user, userRow))
+        }
+
+        if (hasRequiredTermsAgreement(userRow)) {
+          router.replace('/')
+          return
+        }
+      } catch (error) {
+        console.error('Error checking terms agreement state:', error)
+        useToast.error('약관 동의 상태를 확인하지 못했어요.')
+        router.replace('/login')
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    checkAgreementState()
+  }, [router, setUser, storeUser])
+
+  const toggleAll = useCallback(() => {
+    const nextChecked = !isAllChecked
+    setTermsChecked(nextChecked)
+    setPrivacyChecked(nextChecked)
+  }, [isAllChecked])
+
+  const submitAgreement = useCallback(async () => {
+    if (!isAllChecked || !storeUser || isSubmitting) return
+
+    try {
+      setIsSubmitting(true)
+      await agreeRequiredTerms(storeUser.id)
+      useToast.success('약관 동의가 완료됐어요.')
+      router.replace('/')
+    } catch (error) {
+      console.error('Error submitting terms agreement:', error)
+      useToast.error('약관 동의 저장에 실패했어요.')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [isAllChecked, isSubmitting, router, storeUser])
+
+  const logoutAndGoLogin = useCallback(async () => {
+    await supabase.auth.signOut()
+    clearUser()
+    sessionStorage.clear()
+    localStorage.clear()
+    router.replace('/login')
+  }, [clearUser, router])
+
+  return {
+    isLoading,
+    isSubmitting,
+    termsChecked,
+    privacyChecked,
+    isAllChecked,
+    isExitModalOpen,
+    setTermsChecked,
+    setPrivacyChecked,
+    setIsExitModalOpen,
+    toggleAll,
+    submitAgreement,
+    logoutAndGoLogin,
+  }
+}

--- a/src/lib/termsAgreement.ts
+++ b/src/lib/termsAgreement.ts
@@ -1,0 +1,83 @@
+import { User as AuthUser } from '@supabase/supabase-js'
+import { supabase } from '@/lib/supabaseClient'
+import { UserRow } from '@/types/supabase'
+import { User } from '@/types/user'
+
+export const TERMS_VERSION = '2026-05-26'
+export const PRIVACY_VERSION = '2026-05-26'
+
+const USER_ROW_RETRY_COUNT = 2
+const USER_ROW_RETRY_DELAY_MS = 300
+
+const delay = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+export const hasRequiredTermsAgreement = (user: UserRow) =>
+  user.terms_agreed && user.privacy_agreed
+
+export const toUserStoreValue = (
+  authUser: AuthUser,
+  userRow: UserRow,
+): User => {
+  const provider = authUser.app_metadata.provider as 'kakao' | 'google'
+
+  return {
+    id: authUser.id,
+    email: userRow.email || authUser.email || '',
+    socialType: provider,
+    name:
+      userRow.name ||
+      authUser.user_metadata.full_name ||
+      authUser.user_metadata.name ||
+      '',
+    profileImage:
+      userRow.profile_image || authUser.user_metadata.avatar_url || '',
+    tag: Number(userRow.tag),
+  }
+}
+
+export const getCurrentUserRow = async (userId: string) => {
+  for (let attempt = 0; attempt <= USER_ROW_RETRY_COUNT; attempt += 1) {
+    const { data, error } = await supabase
+      .from('user')
+      .select('*')
+      .eq('id', userId)
+      .maybeSingle()
+
+    if (error) {
+      throw error
+    }
+
+    if (data) {
+      return data
+    }
+
+    if (attempt < USER_ROW_RETRY_COUNT) {
+      await delay(USER_ROW_RETRY_DELAY_MS)
+    }
+  }
+
+  return null
+}
+
+export const agreeRequiredTerms = async (userId: string) => {
+  const agreedAt = new Date().toISOString()
+
+  const { error } = await supabase
+    .from('user')
+    .update({
+      terms_agreed: true,
+      terms_agreed_at: agreedAt,
+      terms_version: TERMS_VERSION,
+      privacy_agreed: true,
+      privacy_agreed_at: agreedAt,
+      privacy_version: PRIVACY_VERSION,
+    })
+    .eq('id', userId)
+
+  if (error) {
+    throw error
+  }
+}

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -432,25 +432,43 @@ export type Database = {
           email: string
           id: string
           name: string
+          privacy_agreed: boolean
+          privacy_agreed_at: string | null
+          privacy_version: string | null
           profile_image: string | null
           social_type: string
           tag: string
+          terms_agreed: boolean
+          terms_agreed_at: string | null
+          terms_version: string | null
         }
         Insert: {
           email: string
           id?: string
           name: string
+          privacy_agreed?: boolean
+          privacy_agreed_at?: string | null
+          privacy_version?: string | null
           profile_image?: string | null
           social_type: string
           tag: string
+          terms_agreed?: boolean
+          terms_agreed_at?: string | null
+          terms_version?: string | null
         }
         Update: {
           email?: string
           id?: string
           name?: string
+          privacy_agreed?: boolean
+          privacy_agreed_at?: string | null
+          privacy_version?: string | null
           profile_image?: string | null
           social_type?: string
           tag?: string
+          terms_agreed?: boolean
+          terms_agreed_at?: string | null
+          terms_version?: string | null
         }
         Relationships: []
       }

--- a/supabase/functions/types/database.types.ts
+++ b/supabase/functions/types/database.types.ts
@@ -429,25 +429,43 @@ export type Database = {
           email: string
           id: string
           name: string
+          privacy_agreed: boolean
+          privacy_agreed_at: string | null
+          privacy_version: string | null
           profile_image: string | null
           social_type: string
           tag: string
+          terms_agreed: boolean
+          terms_agreed_at: string | null
+          terms_version: string | null
         }
         Insert: {
           email: string
           id?: string
           name: string
+          privacy_agreed?: boolean
+          privacy_agreed_at?: string | null
+          privacy_version?: string | null
           profile_image?: string | null
           social_type: string
           tag: string
+          terms_agreed?: boolean
+          terms_agreed_at?: string | null
+          terms_version?: string | null
         }
         Update: {
           email?: string
           id?: string
           name?: string
+          privacy_agreed?: boolean
+          privacy_agreed_at?: string | null
+          privacy_version?: string | null
           profile_image?: string | null
           social_type?: string
           tag?: string
+          terms_agreed?: boolean
+          terms_agreed_at?: string | null
+          terms_version?: string | null
         }
         Relationships: []
       }

--- a/supabase/migrations/20260604115951_add_terms_agreement_to_user.sql
+++ b/supabase/migrations/20260604115951_add_terms_agreement_to_user.sql
@@ -1,0 +1,74 @@
+alter table public.user
+  add column if not exists terms_agreed boolean not null default false,
+  add column if not exists terms_agreed_at timestamptz,
+  add column if not exists terms_version text,
+  add column if not exists privacy_agreed boolean not null default false,
+  add column if not exists privacy_agreed_at timestamptz,
+  add column if not exists privacy_version text;
+
+create or replace function public.insert_into_public_users()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+    -- 카카오 로그인 처리
+    if new.raw_app_meta_data->>'provider' = 'kakao' then
+        insert into public.user (
+            email,
+            name,
+            profile_image,
+            social_type,
+            id,
+            tag,
+            terms_agreed,
+            privacy_agreed
+        )
+        values (
+            new.raw_user_meta_data->>'email',
+            coalesce(
+                new.raw_user_meta_data->>'name',
+                new.raw_user_meta_data->>'full_name',
+                new.raw_user_meta_data->>'email',
+                '사용자'
+            ),
+            new.raw_user_meta_data->>'avatar_url',
+            'kakao',
+            new.id,
+            floor(random() * 9000 + 1000),
+            false,
+            false
+        );
+    -- 구글 로그인 처리
+    elsif new.raw_app_meta_data->>'provider' = 'google' then
+        insert into public.user (
+            email,
+            name,
+            profile_image,
+            social_type,
+            id,
+            tag,
+            terms_agreed,
+            privacy_agreed
+        )
+        values (
+            new.raw_user_meta_data->>'email',
+            coalesce(
+                new.raw_user_meta_data->>'name',
+                new.raw_user_meta_data->>'full_name',
+                new.raw_user_meta_data->>'email',
+                '사용자'
+            ),
+            new.raw_user_meta_data->>'avatar_url',
+            'google',
+            new.id,
+            floor(random() * 9000 + 1000),
+            false,
+            false
+        );
+    end if;
+
+    return new;
+end;
+$$;


### PR DESCRIPTION
## #️⃣연관된 이슈

#51

## 📝작업 내용

### 약관 동의 DB 스키마
- user 테이블에 필수 약관 동의 여부, 동의 시각, 버전 컬럼을 추가했습니다.
- 신규 사용자 생성 함수에서 약관 동의 기본값이 false로 저장되도록 반영했습니다.

### 약관 동의 플로우
- 로그인 콜백에서 약관 동의 여부를 확인하고 미동의 사용자를 약관 동의 페이지로 이동하도록 구현했습니다.
- 약관 동의 페이지, 이탈 확인 모달, 동의 저장 로직을 추가했습니다.
- 미동의 사용자가 서비스 라우트로 직접 접근하면 약관 동의 페이지로 이동하도록 보호 로직을 추가했습니다.

### 검색 노출 설정
- 약관 동의 페이지를 sitemap과 robots에서 제외했습니다.

### 스크린샷 (선택)

X

## 💬리뷰 요구사항(선택)

X