### PR TITLE
[feature-54/notification-read] 알림 읽기 기능 구현

### DIFF
--- a/src/app/nbread/[nbreadId]/page.tsx
+++ b/src/app/nbread/[nbreadId]/page.tsx
@@ -6,11 +6,10 @@ import { useToast } from '@/components/common/toast/Toast'
 import { getNbread } from '@/lib/nbread'
 import { getParticipants } from '@/lib/participant'
 import { Nbread, NbreadRecord } from '@/types/nbread'
-import { useRouter, useParams } from 'next/navigation'
+import { useRouter, useParams, useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { getNbreadRecords } from '@/lib/nbreadRecord'
-import useUserStore from '@/stores/useAuthStore'
 import Spinner from '@/components/common/spinner/Spinner'
 import Tabbar from '@/components/common/tabbar/tabbar'
 import ChatRoom from '@/components/chat/ChatRoom'
@@ -23,18 +22,13 @@ const Page = () => {
   )
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const params = useParams()
+  const searchParams = useSearchParams()
   const router = useRouter()
-  const [selectedTab, setSelectedTab] = useState<number>(0)
+  const initialTab = searchParams.get('tab') === 'chat' ? 2 : 0
+  const [selectedTab, setSelectedTab] = useState<number>(initialTab)
 
   const [isEditing, setIsEditing] = useState<boolean>(false)
-  const {
-    register,
-    setValue,
-    getValues,
-    handleSubmit,
-    reset,
-    formState: { isValid },
-  } = useForm<Nbread>({ mode: 'onChange' })
+  const { reset } = useForm<Nbread>({ mode: 'onChange' })
 
   // 엔빵 및 참여자 정보를 DB로부터 불러오는 함수
   const fetchNbreadData = async () => {
@@ -123,7 +117,7 @@ const Page = () => {
 
         <Tabbar
           tabs={['엔빵 정보', '게시판', '채팅방']}
-          initialValue={0}
+          initialValue={initialTab}
           onTabChange={setSelectedTab}
         />
       </div>

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -8,6 +8,7 @@ import {
   getNotification,
   getNotificationDestination,
   getNotificationDestinationError,
+  markNotificationAsRead,
 } from '@/lib/notification'
 import useUserStore from '@/stores/useAuthStore'
 import useNotificationStore from '@/stores/useNotificationStore'
@@ -53,7 +54,9 @@ const Page = () => {
     try {
       const data = await getNotification(userData.id)
       setNotificationData(data)
-      setNotificationCount(data.length)
+      setNotificationCount(
+        data.filter((notification) => !notification.is_read).length,
+      )
       if (data.length > 0) {
         trackEvent(GA_EVENTS.RECEIVE_NOTIFICATION, {
           count: data.length,
@@ -77,7 +80,10 @@ const Page = () => {
         (notification) => notification.id !== notificationId,
       )
       setNotificationData(nextNotifications)
-      setNotificationCount(nextNotifications.length)
+      setNotificationCount(
+        nextNotifications.filter((notification) => !notification.is_read)
+          .length,
+      )
     } catch (error) {
       console.error(error)
       useToast.error('알림 삭제에 실패했어요. 다시 시도해주세요.')
@@ -115,10 +121,24 @@ const Page = () => {
   }, [selectedNotifycationType])
 
   const handleNotificationClick = (notification: Notification) => {
+    if (!userData) return
+
     trackEvent(GA_EVENTS.CLICK_NOTIFICATION, {
       notification_type: notification.type,
       notification_id: notification.id,
     })
+
+    if (!notification.is_read) {
+      const nextNotifications = notificationData.map((item) =>
+        item.id === notification.id ? { ...item, is_read: true } : item,
+      )
+      setNotificationData(nextNotifications)
+      setNotificationCount(
+        nextNotifications.filter((item) => !item.is_read).length,
+      )
+
+      void markNotificationAsRead(notification.id, userData.id).catch(() => {})
+    }
 
     if (notification.type === 'friend_request') {
       const friendData = notification.data as FriendNotificationData | null
@@ -171,7 +191,9 @@ const Page = () => {
         ) : (
           notificationData.map((data) => (
             <div
-              className="card card-clickable relative flex cursor-pointer flex-row justify-between"
+              className={`card card-clickable relative flex cursor-pointer flex-row justify-between ${
+                data.is_read ? 'bg-gray-200' : 'bg-white'
+              }`}
               key={data.id}
               onClick={() => handleNotificationClick(data)}
             >

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -6,6 +6,8 @@ import {
   deleteAllNotifications,
   deleteNotification,
   getNotification,
+  getNotificationDestination,
+  getNotificationDestinationError,
 } from '@/lib/notification'
 import useUserStore from '@/stores/useAuthStore'
 import useNotificationStore from '@/stores/useNotificationStore'
@@ -16,10 +18,6 @@ import FriendAcceptModal from '@/components/friend/FriendAcceptModal'
 import { getRelativeTime } from '@/utils/getRelativeTime'
 import { GA_EVENTS, trackEvent } from '@/lib/analytics/events'
 import { useToast } from '@/components/common/toast/Toast'
-
-interface InviteNotificationData {
-  inviteToken?: string
-}
 
 interface FriendNotificationData {
   sender_name?: string
@@ -115,6 +113,31 @@ const Page = () => {
       setIsAcceptModalOpen(true)
     }
   }, [selectedNotifycationType])
+
+  const handleNotificationClick = (notification: Notification) => {
+    trackEvent(GA_EVENTS.CLICK_NOTIFICATION, {
+      notification_type: notification.type,
+      notification_id: notification.id,
+    })
+
+    if (notification.type === 'friend_request') {
+      const friendData = notification.data as FriendNotificationData | null
+      setSelectedNotifycationId(notification.id)
+      setSelectedNotifycationType(notification.type)
+      setSelectedNotifycationSenderName(friendData?.sender_name ?? null)
+      setSelectedNotifycationSenderId(friendData?.sender_id ?? null)
+      return
+    }
+
+    const destination = getNotificationDestination(notification)
+    if (!destination) {
+      useToast.error(getNotificationDestinationError(notification.type))
+      return
+    }
+
+    router.push(destination)
+  }
+
   if (isLoading) {
     return <Spinner isLoading={isLoading} />
   }
@@ -150,34 +173,7 @@ const Page = () => {
             <div
               className="card card-clickable relative flex cursor-pointer flex-row justify-between"
               key={data.id}
-              onClick={() => {
-                trackEvent(GA_EVENTS.CLICK_NOTIFICATION, {
-                  notification_type: data.type,
-                  notification_id: data.id,
-                })
-                if (data.type === 'invite') {
-                  // 모든 엔빵 초대 알림은 토큰 기반 단일 초대 페이지로 이동한다.
-                  const inviteToken = (
-                    data.data as InviteNotificationData | null
-                  )?.inviteToken
-
-                  if (!inviteToken) {
-                    useToast.error('초대 정보를 찾을 수 없어요.')
-                    return
-                  }
-
-                  router.push(`/invite/${inviteToken}`)
-                } else if (data.type === 'friend_request') {
-                  // 친구 요청 알림일 경우
-                  const friendData = data.data as FriendNotificationData | null
-                  setSelectedNotifycationId(data.id)
-                  setSelectedNotifycationType(data.type)
-                  setSelectedNotifycationSenderName(
-                    friendData?.sender_name ?? null,
-                  )
-                  setSelectedNotifycationSenderId(friendData?.sender_id ?? null)
-                }
-              }}
+              onClick={() => handleNotificationClick(data)}
             >
               <div className="flex w-full flex-col gap-4">
                 <div className="text-body01 text-gray-800">{data.title}</div>

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -9,6 +9,7 @@ import {
   getNotificationDestination,
   getNotificationDestinationError,
   markNotificationAsRead,
+  sortNotifications,
 } from '@/lib/notification'
 import useUserStore from '@/stores/useAuthStore'
 import useNotificationStore from '@/stores/useNotificationStore'
@@ -129,8 +130,10 @@ const Page = () => {
     })
 
     if (!notification.is_read) {
-      const nextNotifications = notificationData.map((item) =>
-        item.id === notification.id ? { ...item, is_read: true } : item,
+      const nextNotifications = sortNotifications(
+        notificationData.map((item) =>
+          item.id === notification.id ? { ...item, is_read: true } : item,
+        ),
       )
       setNotificationData(nextNotifications)
       setNotificationCount(
@@ -163,7 +166,7 @@ const Page = () => {
   }
 
   return (
-    <div className="jusfity-between flex h-screen w-full flex-col overflow-y-hidden">
+    <div className="jusfity-between mb-40 flex h-full w-full flex-col">
       <div className="pl-24 pt-24">
         <DetailHeader />
       </div>

--- a/src/components/home/Header.tsx
+++ b/src/components/home/Header.tsx
@@ -22,7 +22,11 @@ const Header = () => {
     }
 
     getNotification(user.id)
-      .then((notifications) => setNotificationCount(notifications.length))
+      .then((notifications) =>
+        setNotificationCount(
+          notifications.filter((notification) => !notification.is_read).length,
+        ),
+      )
       .catch((error) => {
         console.error('Error fetching notification count:', error)
       })

--- a/src/lib/notification/getNotificationDestination.ts
+++ b/src/lib/notification/getNotificationDestination.ts
@@ -1,0 +1,48 @@
+import type { Notification, NotificationType } from '@/types/notification'
+import type { Json } from '@/types/supabase'
+
+const getStringValue = (data: Json | null, keys: string[]) => {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return null
+
+  for (const key of keys) {
+    const value = data[key]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+
+  return null
+}
+
+export const getNotificationDestination = (
+  notification: Pick<Notification, 'type' | 'data'>,
+): string | null => {
+  const nbreadId = getStringValue(notification.data, ['nbreadId', 'nbread_id'])
+
+  switch (notification.type) {
+    case 'invite': {
+      const inviteToken = getStringValue(notification.data, [
+        'inviteToken',
+        'invite_token',
+      ])
+      return inviteToken ? `/invite/${encodeURIComponent(inviteToken)}` : null
+    }
+    case 'chat':
+      return nbreadId
+        ? `/nbread/${encodeURIComponent(nbreadId)}?tab=chat`
+        : null
+    case 'payment':
+    case 'invite_accept':
+      return nbreadId ? `/nbread/${encodeURIComponent(nbreadId)}` : null
+    case 'friend_response':
+      return '/friendList'
+    case 'friend_request':
+      return null
+  }
+}
+
+export const getNotificationDestinationError = (
+  type: NotificationType,
+): string => {
+  if (type === 'invite') return '초대 정보를 찾을 수 없어요.'
+  if (type === 'friend_request') return ''
+  return '이동할 페이지 정보를 찾을 수 없어요.'
+}

--- a/src/lib/notification/getNotifications.ts
+++ b/src/lib/notification/getNotifications.ts
@@ -2,6 +2,7 @@ import { supabase } from '@/lib/supabaseClient'
 import { Notification, NotificationType } from '@/types/notification'
 import { NotificationRow } from '@/types/supabase'
 import { PostgrestError } from '@supabase/supabase-js'
+import { sortNotifications } from './sortNotifications'
 
 type GetNotificationType = {
   data: NotificationRow[] | null
@@ -33,7 +34,7 @@ export const getNotification = async (userId: string) => {
         is_read: notification.is_read,
       }),
     )
-    return notifications
+    return sortNotifications(notifications)
   } catch (error) {
     console.error('Error fetching notifications:', error)
     throw error

--- a/src/lib/notification/getNotifications.ts
+++ b/src/lib/notification/getNotifications.ts
@@ -1,5 +1,5 @@
 import { supabase } from '@/lib/supabaseClient'
-import { Notification } from '@/types/notification'
+import { Notification, NotificationType } from '@/types/notification'
 import { NotificationRow } from '@/types/supabase'
 import { PostgrestError } from '@supabase/supabase-js'
 
@@ -29,7 +29,7 @@ export const getNotification = async (userId: string) => {
         title: notification.title,
         message: notification.message,
         data: notification.data,
-        type: notification.type,
+        type: notification.type as NotificationType,
         is_read: notification.is_read,
       }),
     )

--- a/src/lib/notification/index.ts
+++ b/src/lib/notification/index.ts
@@ -7,3 +7,4 @@ export {
   deleteAllNotifications,
   deleteNotification,
 } from './deleteNotifications'
+export { markNotificationAsRead } from './markNotificationAsRead'

--- a/src/lib/notification/index.ts
+++ b/src/lib/notification/index.ts
@@ -8,3 +8,4 @@ export {
   deleteNotification,
 } from './deleteNotifications'
 export { markNotificationAsRead } from './markNotificationAsRead'
+export { sortNotifications } from './sortNotifications'

--- a/src/lib/notification/index.ts
+++ b/src/lib/notification/index.ts
@@ -1,5 +1,9 @@
 export { getNotification } from './getNotifications'
 export {
+  getNotificationDestination,
+  getNotificationDestinationError,
+} from './getNotificationDestination'
+export {
   deleteAllNotifications,
   deleteNotification,
 } from './deleteNotifications'

--- a/src/lib/notification/markNotificationAsRead.ts
+++ b/src/lib/notification/markNotificationAsRead.ts
@@ -1,0 +1,21 @@
+import { supabase } from '@/lib/supabaseClient'
+
+export const markNotificationAsRead = async (
+  notificationId: number,
+  userId: string,
+) => {
+  const { data, error } = await supabase
+    .from('notification')
+    .update({ is_read: true })
+    .eq('id', notificationId)
+    .eq('user_id', userId)
+    .select('id')
+
+  if (error) {
+    throw error
+  }
+
+  if (data.length !== 1) {
+    throw new Error('Notification not found or not owned by the current user')
+  }
+}

--- a/src/lib/notification/sortNotifications.ts
+++ b/src/lib/notification/sortNotifications.ts
@@ -1,0 +1,15 @@
+import type { Notification } from '@/types/notification'
+
+export const sortNotifications = (
+  notifications: Notification[],
+): Notification[] =>
+  [...notifications].sort((a, b) => {
+    if (a.is_read !== b.is_read) {
+      return Number(a.is_read) - Number(b.is_read)
+    }
+
+    const createdAtDifference =
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+
+    return createdAtDifference || b.id - a.id
+  })

--- a/src/types/notification.ts
+++ b/src/types/notification.ts
@@ -1,5 +1,13 @@
 import { Json } from './supabase'
 
+export type NotificationType =
+  | 'payment'
+  | 'chat'
+  | 'invite'
+  | 'invite_accept'
+  | 'friend_request'
+  | 'friend_response'
+
 export interface Notification {
   id: number
   user_id: string
@@ -8,6 +16,5 @@ export interface Notification {
   message: string
   data: Json | null
   is_read: boolean
-  type: string // TODO 알림 타입 수정 필요
-  // sender_name: string
+  type: NotificationType
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #151

## 📝작업 내용
### 알림 클릭 시 관련 페이지 라우팅 구현
- 알림 클릭 시 엔빵 상세페이지, 채팅방, 게시글 페이지 등 관련 페이지로 라우팅하는 기능을 구현했습니다.

### 알림 클릭 시 읽기 처리 구현
- 알림을 클릭 시 is_read를 true로 업데이트하는 함수를 구현했습니다.
- 알림을 클릭 시 알림 읽기 여부를 낙관적으로 업데이트하도록 구현했습니다.
- 알림 읽기 처리에 실패한 경우 에러를 사용자에게 노출하지 않고 throw합니다.

### 알림 읽기 상태에 따른 정렬 구현
- 읽지 않은 알림을 상단에 표시하도록 정렬을 구현했습니다.
- 각 상태 그룹 내부에서는 최신순으로 정렬됩니다.

### 스크린샷 (선택)
X

## 💬리뷰 요구사항(선택)
X