### PR TITLE
[chore-56/check-before-prod] 배포 전 점검

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "andbread",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "private": false,
   "scripts": {
     "dev": "next dev",

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -15,7 +15,7 @@ export default function PrivacyPolicyPage() {
       <article className="mx-auto mt-20 max-w-[600px]">
         <h1 className="text-gray-800">개인정보처리방침</h1>
         <p className="mt-12 text-body03 text-gray-500">
-          시행일: 2026년 5월 26일 | 최종 수정일: 2025년 5월 22일
+          시행일: 2026년 6월 11일 | 최종 수정일: 2025년 5월 22일
         </p>
 
         <p className="mt-20 text-paragraph text-gray-700">

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -15,7 +15,7 @@ export default function TermsOfServicePage() {
       <article className="mx-auto mt-20 max-w-[600px]">
         <h1 className="text-gray-800">엔빵 서비스 이용약관</h1>
         <p className="mt-12 text-body03 text-gray-500">
-          시행일: 2026년 5월 26일 | 최종 수정일: 2026년 5월 22일
+          시행일: 2026년 6월 11일 | 최종 수정일: 2026년 5월 22일
         </p>
 
         <section className="mt-32">

--- a/src/components/nbread/nbreadParticipantCard.tsx
+++ b/src/components/nbread/nbreadParticipantCard.tsx
@@ -45,10 +45,11 @@ const NbreadParticipantCard = (props: NbreadParticipantCardProps) => {
         })
       }
 
-      useToast.success('완료 여부 업데이트에 성공했어요.')
+      useToast.success('완료 여부가 업데이트되었어요.')
       setIsChecked((prev) => !prev)
     } catch (error) {
       useToast.error('완료 여부 업데이트에 실패했어요. 다시 시도해주세요.')
+      throw error
     }
 
     setTimeout(() => {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #154 

## 📝작업 내용

- 정책 시행일자를 오늘(6/11)로 업데이트했습니다.
- 납부 완료 여부 업데이트 토스트의 문구를 수정했습니다.
- package.json 파일 내의 버전을 2.0.0으로 업데이트했습니다. 

### 스크린샷 (선택)
X

## 💬리뷰 요구사항(선택)
X