### PR TITLE
[fix-62/friend-invite] 친구 초대 오류 해결

### DIFF
--- a/supabase/migrations/20260702083718_secure_invite_response_rpc.sql
+++ b/supabase/migrations/20260702083718_secure_invite_response_rpc.sql
@@ -1,0 +1,122 @@
+create or replace function public.respond_to_nbread_invite(
+  p_invite_token text,
+  p_response text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_invite public.nbread_invite%rowtype;
+  v_user_id uuid := auth.uid();
+  v_participant_limit integer;
+  v_participant_count bigint;
+  v_participant_inserted boolean := false;
+  v_already_participant boolean := false;
+begin
+  if p_response not in ('accepted', 'rejected') then
+    raise exception 'INVALID_INVITE_RESPONSE';
+  end if;
+
+  -- 동일 초대에 대한 동시 응답을 직렬화해 상태 변경을 한 번만 처리한다.
+  select *
+    into v_invite
+    from public.nbread_invite
+   where invite_token = p_invite_token
+   for update;
+
+  if not found then
+    raise exception 'INVITE_NOT_FOUND';
+  end if;
+
+  if v_invite.status = 'accepted' then
+    raise exception 'INVITE_ALREADY_ACCEPTED';
+  elsif v_invite.status = 'rejected' then
+    raise exception 'INVITE_ALREADY_REJECTED';
+  elsif v_invite.status = 'expired' then
+    raise exception 'INVITE_EXPIRED';
+  end if;
+
+  if v_user_id is null then
+    raise exception 'LOGIN_REQUIRED';
+  end if;
+
+  if v_invite.target_user_id is not null
+     and v_user_id <> v_invite.target_user_id then
+    raise exception 'INVITE_TARGET_MISMATCH';
+  end if;
+
+  if p_response = 'accepted' then
+    if v_invite.target_user_id is null then
+      -- 링크 초대는 수락 시점의 로그인 사용자를 초대 대상자로 연결한다.
+      update public.nbread_invite
+         set target_user_id = v_user_id
+       where id = v_invite.id;
+
+      v_invite.target_user_id := v_user_id;
+    end if;
+
+    select exists (
+      select 1
+        from public.participant
+       where nbread_id = v_invite.nbread_id
+         and user_id = v_invite.target_user_id
+    )
+      into v_already_participant;
+
+    if not v_already_participant then
+      -- 서로 다른 초대를 동시에 수락해도 정원 확인과 참여자 생성을 직렬화한다.
+      select participant_count
+        into v_participant_limit
+        from public.nbread
+       where id = v_invite.nbread_id
+       for update;
+
+      if not found then
+        raise exception 'NBREAD_NOT_FOUND';
+      end if;
+
+      select count(*)
+        into v_participant_count
+        from public.participant
+       where nbread_id = v_invite.nbread_id;
+
+      if v_participant_count >= v_participant_limit then
+        raise exception 'INVITE_EXPIRED';
+      end if;
+
+      -- 함수 내부 검증을 통과한 초대 응답만 참여자로 등록한다.
+      insert into public.participant (nbread_id, user_id, is_leader)
+      values (v_invite.nbread_id, v_invite.target_user_id, false)
+      on conflict (nbread_id, user_id) do nothing;
+
+      v_participant_inserted := found;
+    end if;
+  end if;
+
+  update public.nbread_invite
+     set status = p_response
+   where id = v_invite.id;
+
+  return jsonb_build_object(
+    'invite_id', v_invite.id,
+    'nbread_id', v_invite.nbread_id,
+    'status', p_response,
+    'outcome',
+      case
+        when p_response = 'rejected' then 'rejected'
+        when v_participant_inserted then 'joined'
+        else 'already_participant'
+      end
+  );
+end;
+$$;
+
+comment on function public.respond_to_nbread_invite(text, text) is
+  '초대 상태와 대상을 검증하고 RLS로 보호된 참여자 생성을 제한적으로 처리';
+
+revoke execute on function public.respond_to_nbread_invite(text, text)
+  from public, anon;
+grant execute on function public.respond_to_nbread_invite(text, text)
+  to authenticated;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #169

## 📝작업 내용

### 초대 수락 RPC RLS 오류 해결

- 친구/링크 초대 수락 시 `participant` 테이블 insert가 RLS 정책에 막혀 `42501 new row violates row-level security policy for table "participant"` 오류가 발생하던 문제를 수정했습니다.
- `respond_to_nbread_invite` RPC를 `security definer`로 재정의해, 함수 내부 검증을 통과한 초대 수락만 제한적으로 `participant`를 생성할 수 있도록 변경했습니다.

### 앞으로 고려해야 할 사항

- 현재 RPC가 초대 수락 API 역할까지 맡고 있어 DB 함수의 책임이 큰 상태입니다.
- 중장기적으로 Next.js API Route로 초대 수락 도메인 로직을 이전하는 방향을 검토할 필요가 있습니다.
- 단, API로 이전할 경우에도 서버에서 로그인 사용자, 초대 토큰, 초대 상태, 정원, 대상자 검증을 현재 RPC 수준으로 유지해야 합니다.
- DB에는 unique constraint, FK, 최소 RLS policy 등 데이터 무결성과 접근 제어 핵심 책임만 남기는 방향을 고려할 수 있습니다.

### 스크린샷 (선택)

X

## 💬리뷰 요구사항(선택)

X