### PR TITLE
[feature-68/seo-metadata] 페이지별 metadata 및 canonical 정리

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
-  siteUrl: process.env.SITE_URL || 'https://nbread-nbread.vercel.app',
+  siteUrl: 'https://www.nbread.co.kr',
   generateRobotsTxt: true,
   changefreq: 'weekly',
   priority: 0.7,

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -16,7 +16,7 @@ Disallow: /notification
 Disallow: /terms-agreement
 
 # Host
-Host: https://nbread-nbread.vercel.app
+Host: https://www.nbread.co.kr
 
 # Sitemaps
-Sitemap: https://nbread-nbread.vercel.app/sitemap.xml
+Sitemap: https://www.nbread.co.kr/sitemap.xml

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://nbread-nbread.vercel.app/ios-guide</loc><lastmod>2026-07-08T09:43:41.344Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://nbread-nbread.vercel.app</loc><lastmod>2026-07-08T09:43:41.347Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://nbread-nbread.vercel.app/privacy-policy</loc><lastmod>2026-07-08T09:43:41.347Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://nbread-nbread.vercel.app/terms-of-service</loc><lastmod>2026-07-08T09:43:41.347Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.nbread.co.kr/ios-guide</loc><lastmod>2026-07-09T15:37:43.343Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.nbread.co.kr/privacy-policy</loc><lastmod>2026-07-09T15:37:43.343Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.nbread.co.kr</loc><lastmod>2026-07-09T15:37:43.343Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.nbread.co.kr/terms-of-service</loc><lastmod>2026-07-09T15:37:43.343Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<sitemap><loc>https://nbread-nbread.vercel.app/sitemap-0.xml</loc></sitemap>
+<sitemap><loc>https://www.nbread.co.kr/sitemap-0.xml</loc></sitemap>
 </sitemapindex>

--- a/src/app/ios-guide/page.tsx
+++ b/src/app/ios-guide/page.tsx
@@ -1,7 +1,13 @@
-'use client'
-
 import DetailHeader from '@/components/common/header/DetailHeader'
 import Image from 'next/image'
+import { createPageMetadata } from '@/lib/seo'
+
+export const metadata = createPageMetadata({
+  title: 'iOS 홈 화면 추가 가이드',
+  description:
+    'iPhone Safari에서 엔빵을 홈 화면에 추가하고 앱처럼 실행하는 방법을 단계별로 안내합니다.',
+  path: '/ios-guide',
+})
 
 const addToHomeSteps = [
   {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,9 +6,10 @@ import GoogleAnalytics from '@/lib/analytics/GoogleAnalytics'
 import PageViewTracker from '@/lib/analytics/PageViewTracker'
 import ClarityProvider from '@/lib/analytics/ClarityProvider'
 import Footer from '@/components/common/Footer'
+import { SITE_URL } from '@/lib/seo'
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://nbread-nbread.vercel.app'),
+  metadataBase: new URL(SITE_URL),
   title: {
     default: '엔빵',
     template: '%s | 엔빵',
@@ -26,9 +27,6 @@ export const metadata: Metadata = {
   ],
   applicationName: '엔빵',
   manifest: '/manifest.json',
-  alternates: {
-    canonical: '/',
-  },
   robots: {
     index: true,
     follow: true,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,15 @@ import Icon, { type IconType } from '@/components/common/icon/Icon'
 import NbreadsImage from '@/components/common/nbreadImage/NbreadsImage'
 import RevealOnScroll from '@/components/landing/RevealOnScroll'
 import NbreadLogo from '@/assets/logo/nbread-logo-text.svg'
+import { createPageMetadata } from '@/lib/seo'
+
+export const metadata = createPageMetadata({
+  title: '엔빵',
+  description:
+    '친구와 가족과 나누는 구독 서비스의 결제일과 정산 현황을 한 곳에서 관리하는 구독 공유 관리 서비스',
+  path: '/',
+  absoluteTitle: true,
+})
 
 const painCards: {
   icon: IconType

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -1,9 +1,12 @@
 import DetailHeader from '@/components/common/header/DetailHeader'
-import type { Metadata } from 'next'
+import { createPageMetadata } from '@/lib/seo'
 
-export const metadata: Metadata = {
+export const metadata = createPageMetadata({
   title: '개인정보처리방침',
-}
+  description:
+    '엔빵의 개인정보 수집 항목, 이용 목적, 보유 기간, 처리 위탁, 이용자 권리와 보호 조치를 안내합니다.',
+  path: '/privacy-policy',
+})
 
 const sectionTitleClass = 'text-heading04 text-gray-800 mt-16'
 const bodyClass = 'mt-8 whitespace-pre-line text-paragraph text-gray-700'
@@ -115,7 +118,7 @@ export default function PrivacyPolicyPage() {
           <h2 className={sectionTitleClass}>10. 개인정보 보호책임자 및 문의</h2>
           <p className={bodyClass}>
             서비스명: 엔빵(N빵)
-            {'\n'}서비스 URL: https://nbread-nbread.vercel.app
+            {'\n'}서비스 URL: https://www.nbread.co.kr
             {'\n'}팀명: 엔빵(andbread)
             {'\n'}문의: GitHub Issues
             (https://github.com/andbread/Andbread_Frontend/issues)

--- a/src/app/terms-of-service/page.tsx
+++ b/src/app/terms-of-service/page.tsx
@@ -1,9 +1,12 @@
 import DetailHeader from '@/components/common/header/DetailHeader'
-import type { Metadata } from 'next'
+import { createPageMetadata } from '@/lib/seo'
 
-export const metadata: Metadata = {
-  title: '서비스이용약관',
-}
+export const metadata = createPageMetadata({
+  title: '서비스 이용약관',
+  description:
+    '엔빵 구독 공유 관리 서비스의 이용 조건, 이용자 의무, 서비스 제공 범위와 책임 기준을 안내합니다.',
+  path: '/terms-of-service',
+})
 
 const sectionTitleClass = 'text-heading04 text-gray-800 mt-16'
 const bodyClass = 'mt-8 whitespace-pre-line text-paragraph text-gray-700'

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next'
+
+export const SITE_URL = 'https://www.nbread.co.kr'
+
+const SITE_NAME = '엔빵'
+const OG_IMAGE = {
+  url: '/assets/logo/open-graph-logo.png',
+  width: 1200,
+  height: 630,
+  alt: '엔빵 로고',
+}
+
+interface PageMetadataParams {
+  title: string
+  description: string
+  path: string
+  absoluteTitle?: boolean
+}
+
+export const createPageMetadata = ({
+  title,
+  description,
+  path,
+  absoluteTitle = false,
+}: PageMetadataParams): Metadata => {
+  const socialTitle = absoluteTitle ? title : `${title} | ${SITE_NAME}`
+
+  return {
+    title: absoluteTitle ? { absolute: title } : title,
+    description,
+    alternates: {
+      canonical: path,
+    },
+    openGraph: {
+      title: socialTitle,
+      description,
+      url: path,
+      siteName: SITE_NAME,
+      locale: 'ko_KR',
+      type: 'website',
+      images: [OG_IMAGE],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: socialTitle,
+      description,
+      images: [OG_IMAGE.url],
+    },
+  }
+}


### PR DESCRIPTION
## Summary

> 공개 페이지별 metadata와 canonical을 페이지 목적에 맞게 분리했습니다.
> `metadataBase`, OG/Twitter URL, sitemap/robots URL 기준을 서비스 공개 주소 `https://www.nbread.co.kr`로 통일했습니다.
> 전역 canonical `/` 고정으로 다른 공개 페이지가 루트 canonical을 상속할 위험을 제거했습니다.

---

## Why

### 왜 이 작업을 진행했나요?

- 기존 전역 metadata에 `alternates.canonical: '/'`가 설정되어 있어 `/privacy-policy`, `/terms-of-service`, `/ios-guide` 같은 공개 페이지가 루트 canonical을 상속할 위험이 있었습니다.
- 공개 페이지별 title, description, canonical, Open Graph/Twitter URL이 분리되어 있지 않아 검색엔진과 공유 미리보기가 각 페이지의 목적을 정확히 반영하기 어려웠습니다.
- 서비스 공개 주소가 `https://www.nbread.co.kr`로 확정되어 metadata URL 기준과 sitemap 생성 기준을 같은 공개 주소로 정렬해야 했습니다.

---

## Decision

### 어떤 구현 방식을 선택했나요?

- `src/lib/seo.ts`에 `SITE_URL`과 `createPageMetadata` helper를 추가해 공개 페이지 metadata 작성 방식을 공통화했습니다.
- 전역 `layout.tsx`는 `metadataBase`, 공통 robots, icons, 기본 OG/Twitter 정보만 담당하도록 두고, 전역 canonical `/` 고정값은 제거했습니다.
- `/`, `/ios-guide`, `/privacy-policy`, `/terms-of-service`는 각각 페이지 목적에 맞는 title, description, canonical, OG/Twitter 정보를 명시했습니다.
- `next-sitemap.config.js`의 `siteUrl`은 이슈 범위에 맞춰 공개 주소 `https://www.nbread.co.kr`로 고정했습니다.

- 검토한 대안
  - 각 페이지에서 metadata 객체를 모두 직접 작성할 수 있지만, canonical/OG/Twitter 구성 중복이 커지고 URL 기준이 다시 흩어질 수 있어 공통 helper를 선택했습니다.
  - sitemap/robots 정책 전체를 함께 정리할 수 있지만, 이번 이슈는 사이트 URL 기준 정렬과 metadata/canonical 정리에 집중하므로 포함/제외 정책 변경은 확장하지 않았습니다.

---

## Changes

### 무엇이 변경되었나요?

#### Feature

- `SITE_URL`을 `https://www.nbread.co.kr`로 정의하고 공개 페이지 metadata helper를 추가했습니다.
- `/`, `/ios-guide`, `/privacy-policy`, `/terms-of-service`에 페이지별 metadata를 추가 또는 보완했습니다.
- 공개 페이지별 canonical, Open Graph URL, Twitter title/description이 각 페이지 URL과 목적에 맞게 생성되도록 정리했습니다.
- `next-sitemap.config.js`, `public/robots.txt`, `public/sitemap.xml`, `public/sitemap-0.xml`을 공개 주소 기준으로 갱신했습니다.

#### Fix

- 전역 canonical `/` 고정값을 제거해 공개 페이지가 루트 canonical을 잘못 상속할 위험을 줄였습니다.
- 개인정보처리방침 본문에 남아 있던 기존 Vercel 서비스 URL을 공개 주소로 교체했습니다.

#### Refactor

- 공개 페이지 metadata 생성 로직을 `createPageMetadata`로 공통화했습니다.

#### Test

- 직접 테스트 코드는 추가하지 않았습니다.

#### Docs

- 문서 파일 변경은 없습니다.

---

## Trade-off

### 한계와 트레이드오프

- `next-sitemap.config.js`의 `siteUrl`은 공개 주소로 고정했습니다. preview/staging 환경별 sitemap이 필요해지면 env 기반 분기 여부를 다시 검토해야 합니다.
- sitemap 포함/제외 정책과 robots 정책 전면 정리는 이번 이슈의 Non-goal이므로 기존 정책을 유지했습니다.
- JSON-LD, Search Console 등록, 랜딩페이지 E2E 검증은 후속 이슈 범위로 남겼습니다.

---

## Impact

### 기존 기능에 미치는 영향

- UI 화면 동작이나 라우팅 정책은 변경하지 않았습니다.
- `/ios-guide`에서 `'use client'`를 제거했지만, 해당 페이지 자체는 hook을 사용하지 않고 client component인 `DetailHeader`를 렌더링하는 구조라 빌드에서 정상 확인했습니다.
- 배포 후 공개 페이지의 canonical, OG/Twitter 미리보기, sitemap/robots URL 기준이 `https://www.nbread.co.kr`로 변경됩니다.

---

## Edge Cases

### Edge Case 및 실패 시나리오

- 공개 주소가 다시 변경되면 `SITE_URL`과 `next-sitemap.config.js`의 `siteUrl`을 함께 변경해야 합니다.
- 검색엔진 반영은 배포 직후 즉시 보장되지 않으며, Search Console 등록/제출 후 색인 상태를 별도로 확인해야 합니다.
- 공유 미리보기 캐시는 외부 플랫폼별로 갱신 시점이 다를 수 있습니다.

---

## Review Points

### 리뷰어가 집중해서 봐야 할 부분

#### 🔴 High

- 없음

#### 🟡 Medium

- 공개 페이지별 canonical이 `https://www.nbread.co.kr` 기준의 올바른 URL을 가리키는지 확인해주세요.
- `SITE_URL`과 `next-sitemap.config.js`의 `siteUrl`을 공개 주소로 고정한 결정이 운영 방식과 맞는지 확인해주세요.
- `/ios-guide`의 server page 전환이 페이지 동작에 영향을 주지 않는지 확인해주세요.

#### 🟢 Low

- 페이지별 title/description 문구가 실제 페이지 목적과 맞는지 확인해주세요.

---

## Validation

### 어떻게 검증했나요?

- [ ] 단위 테스트
- [ ] E2E 테스트
- [x] 수동 테스트
- [ ] lint
- [x] typecheck

- `npm run build` 성공
- `npm run generate-sitemap` 성공
- 빌드 산출 HTML에서 `/`, `/ios-guide`, `/privacy-policy`, `/terms-of-service`의 title, description, canonical, OG/Twitter URL 확인
- `git diff --check` 통과
- `npm run lint`는 실행했으나 기존 lint 오류로 실패했습니다.
  - 대표 원인: `src/app/not-found.tsx`의 `any`, `src/components/nbread/NbreadDetail.tsx`의 hook rule 오류 등 이번 변경과 무관한 기존 오류

Closes #179