### PR TITLE
[cicd-72/release-auto-create] Vercel 배포 성공 후 태그 및 GitHub Release 자동 생성

### DIFF
--- a/.github/workflows/create-release-note.yml
+++ b/.github/workflows/create-release-note.yml
@@ -15,7 +15,9 @@ jobs:
   create-release:
     if: >-
       github.event.context == 'Vercel' &&
-      github.event.state == 'success'
+      github.event.state == 'success' &&
+      github.event.sender.login == 'vercel[bot]' &&
+      startsWith(github.event.target_url, 'https://vercel.com/hm1n/nbread/')
     runs-on: ubuntu-latest
     env:
       EVENT_SHA: ${{ github.event.sha }}
@@ -129,9 +131,14 @@ jobs:
             exit 1
           fi
 
+          if [[ "$END_LINE" -le "$((START_LINE + 1))" ]]; then
+            echo "릴리즈 노트 마커 사이에 본문이 없습니다." >&2
+            exit 1
+          fi
+
           sed -n "$((START_LINE + 1)),$((END_LINE - 1))p" <<< "$PR_BODY" > release-notes.md
-          if [[ ! -s release-notes.md ]]; then
-            echo "릴리즈 PR에서 추출한 릴리즈 노트가 비어 있습니다." >&2
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "릴리즈 PR에서 추출한 릴리즈 노트에 비공백 내용이 없습니다." >&2
             exit 1
           fi
 

--- a/.github/workflows/create-release-note.yml
+++ b/.github/workflows/create-release-note.yml
@@ -1,0 +1,211 @@
+name: Create production release
+
+on:
+  status:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: production-release-${{ github.event.sha }}-${{ github.event.context }}-${{ github.event.state }}
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    if: >-
+      github.event.context == 'Vercel' &&
+      github.event.state == 'success'
+    runs-on: ubuntu-latest
+    env:
+      EVENT_SHA: ${{ github.event.sha }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Verify latest main deployment
+        id: main
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch origin main --tags
+
+          MAIN_SHA="$(git rev-parse origin/main)"
+          if [[ "$MAIN_SHA" != "$EVENT_SHA" ]]; then
+            echo "현재 main 최신 커밋의 배포가 아니므로 릴리즈를 생성하지 않습니다."
+            echo "event_sha=$EVENT_SHA"
+            echo "main_sha=$MAIN_SHA"
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Vercel 성공 상태가 현재 main 최신 커밋과 일치합니다: $EVENT_SHA"
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve release pull request
+        if: steps.main.outputs.eligible == 'true'
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          PULLS_JSON="$(
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              "repos/${GITHUB_REPOSITORY}/commits/${EVENT_SHA}/pulls?per_page=100"
+          )"
+
+          MATCHING_PULLS="$(
+            jq \
+              --arg repository "$GITHUB_REPOSITORY" \
+              '[
+                .[]
+                | select(
+                    .merged_at != null
+                    and .base.ref == "main"
+                    and .head.ref == "develop"
+                    and .head.repo.full_name == $repository
+                    and (.title | test("^\\[release\\] v[0-9]+\\.[0-9]+\\.[0-9]+$"))
+                  )
+              ]' \
+              <<< "$PULLS_JSON"
+          )"
+
+          PULL_COUNT="$(jq 'length' <<< "$MATCHING_PULLS")"
+          if [[ "$PULL_COUNT" -ne 1 ]]; then
+            echo "배포 SHA에 연결된 유효한 릴리즈 PR은 정확히 1개여야 합니다. 발견: $PULL_COUNT" >&2
+            jq -r '.[] | "- #\(.number) \(.title) (\(.head.ref) -> \(.base.ref))"' <<< "$MATCHING_PULLS" >&2
+            exit 1
+          fi
+
+          PR_NUMBER="$(jq -r '.[0].number' <<< "$MATCHING_PULLS")"
+          PR_TITLE="$(jq -r '.[0].title' <<< "$MATCHING_PULLS")"
+          PR_BODY="$(jq -r '.[0].body // ""' <<< "$MATCHING_PULLS")"
+
+          if [[ "$PR_TITLE" =~ ^\[release\]\ (v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+          else
+            echo "릴리즈 PR 제목 형식이 올바르지 않습니다: $PR_TITLE" >&2
+            exit 1
+          fi
+
+          BODY_VERSION="$(
+            awk '
+              /^## 릴리즈 버전[[:space:]]*$/ { in_version_section = 1; next }
+              in_version_section && /^## / { exit }
+              in_version_section && match($0, /`v[0-9]+\.[0-9]+\.[0-9]+`/) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+              }
+            ' <<< "$PR_BODY"
+          )"
+
+          if [[ "$BODY_VERSION" != "$VERSION" ]]; then
+            echo "릴리즈 PR 제목과 본문의 버전이 일치하지 않습니다." >&2
+            echo "title_version=$VERSION" >&2
+            echo "body_version=${BODY_VERSION:-missing}" >&2
+            exit 1
+          fi
+
+          START_COUNT="$(grep -cF '<!-- release-note:start -->' <<< "$PR_BODY" || true)"
+          END_COUNT="$(grep -cF '<!-- release-note:end -->' <<< "$PR_BODY" || true)"
+          if [[ "$START_COUNT" -ne 1 || "$END_COUNT" -ne 1 ]]; then
+            echo "릴리즈 노트 시작/종료 마커가 각각 정확히 1개 필요합니다." >&2
+            echo "start_count=$START_COUNT" >&2
+            echo "end_count=$END_COUNT" >&2
+            exit 1
+          fi
+
+          START_LINE="$(grep -nF '<!-- release-note:start -->' <<< "$PR_BODY" | cut -d: -f1)"
+          END_LINE="$(grep -nF '<!-- release-note:end -->' <<< "$PR_BODY" | cut -d: -f1)"
+          if [[ "$START_LINE" -ge "$END_LINE" ]]; then
+            echo "릴리즈 노트 마커의 순서가 올바르지 않습니다." >&2
+            exit 1
+          fi
+
+          sed -n "$((START_LINE + 1)),$((END_LINE - 1))p" <<< "$PR_BODY" > release-notes.md
+          if [[ ! -s release-notes.md ]]; then
+            echo "릴리즈 PR에서 추출한 릴리즈 노트가 비어 있습니다." >&2
+            exit 1
+          fi
+
+          echo "릴리즈 PR을 확인했습니다: #$PR_NUMBER $PR_TITLE"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create or recover production release
+        if: steps.main.outputs.eligible == 'true'
+        shell: bash
+        env:
+          PR_NUMBER: ${{ steps.release.outputs.pr_number }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          TAG_REF="$(git ls-remote --tags origin "refs/tags/${VERSION}")"
+          if [[ -n "$TAG_REF" ]]; then
+            TAG_EXISTS=true
+          else
+            TAG_EXISTS=false
+          fi
+
+          if gh api --silent "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}" 2> release-error.txt; then
+            RELEASE_EXISTS=true
+          elif grep -q 'HTTP 404' release-error.txt; then
+            RELEASE_EXISTS=false
+          else
+            echo "GitHub Release 존재 여부를 확인하지 못했습니다." >&2
+            cat release-error.txt >&2
+            exit 1
+          fi
+
+          if [[ "$TAG_EXISTS" == true ]]; then
+            git fetch origin "refs/tags/${VERSION}:refs/tags/${VERSION}"
+            TAG_SHA="$(git rev-list -n 1 "$VERSION")"
+            if [[ "$TAG_SHA" != "$EVENT_SHA" ]]; then
+              echo "기존 태그가 현재 배포 SHA와 다른 커밋을 가리킵니다." >&2
+              echo "version=$VERSION" >&2
+              echo "tag_sha=$TAG_SHA" >&2
+              echo "event_sha=$EVENT_SHA" >&2
+              exit 1
+            fi
+          fi
+
+          if [[ "$TAG_EXISTS" == true && "$RELEASE_EXISTS" == true ]]; then
+            echo "태그와 GitHub Release가 이미 존재합니다: $VERSION"
+            exit 0
+          fi
+
+          if [[ "$TAG_EXISTS" == false && "$RELEASE_EXISTS" == true ]]; then
+            echo "GitHub Release는 존재하지만 대응하는 Git 태그가 없습니다: $VERSION" >&2
+            exit 1
+          fi
+
+          if [[ "$TAG_EXISTS" == false ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git tag -a "$VERSION" "$EVENT_SHA" -m "$VERSION"
+            git push origin "refs/tags/${VERSION}"
+            echo "배포 SHA에 태그를 생성했습니다: $VERSION -> $EVENT_SHA"
+          else
+            echo "기존 태그를 사용해 GitHub Release 생성을 재시도합니다: $VERSION"
+          fi
+
+          gh release create "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$VERSION" \
+            --notes-file release-notes.md \
+            --verify-tag
+
+          {
+            echo "### Production release"
+            echo "- Version: \`$VERSION\`"
+            echo "- Commit: \`$EVENT_SHA\`"
+            echo "- Pull Request: #$PR_NUMBER"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

> Vercel 프로덕션 배포 성공 후 배포된 `main` 커밋에 Git 태그와 GitHub Release를 자동 생성합니다.
> Preview 배포, 중복 이벤트, 태그만 생성된 부분 실패를 구분해 안전하게 처리합니다.
> 릴리즈 PR의 버전과 공개 릴리즈 노트 영역을 검증해 GitHub Release 본문으로 사용합니다.

---

## Why

### 왜 이 작업을 진행했나요?

- 프로덕션 배포 후 태그 생성과 릴리즈 노트 게시를 수동으로 반복해야 했습니다.
- Vercel Preview와 Production이 동일한 `Vercel` status context를 사용할 수 있어, success 상태만 확인하면 Preview 커밋을 릴리즈할 위험이 있습니다.
- 동일 status 재수신이나 태그 생성 후 Release 발행 실패가 발생해도 중복 없이 복구할 수 있는 자동화가 필요합니다.

---

## Decision

### 어떤 구현 방식을 선택했나요?

- 기존 `main push → Vercel Production` 배포 경로는 유지하고, GitHub Actions가 `status` 이벤트를 관찰하는 방식으로 구현했습니다.
- `Vercel success`, status sender가 `vercel[bot]`인지, `target_url`이 현재 Vercel 프로젝트 경로인지, 이벤트 SHA가 최신 `origin/main` SHA와 일치하는 조건을 모두 만족할 때만 릴리즈 처리를 진행합니다.
- 배포 SHA에 연결된 `develop → main` merged PR 중 제목이 `[release] vX.Y.Z`인 PR을 정확히 하나 찾고, 제목과 본문의 버전 일치를 검증합니다.
- PR 본문의 `release-note:start` / `release-note:end` 사이만 공개 Release 본문으로 추출합니다.
- 태그와 Release 존재 여부를 조합해 신규 생성, 부분 실패 복구, 중복 종료, 비정상 상태 실패를 구분합니다.
- `deployment_status` 이벤트와 Vercel CLI 기반 별도 배포는 현재 저장소에서 확인된 배포 흐름과 맞지 않아 선택하지 않았습니다.

---

## Changes

### 무엇이 변경되었나요?

#### Feature

- `.github/workflows/create-release-note.yml` 추가
- Vercel success 및 최신 `main` SHA 검증
- 배포 커밋에 연결된 릴리즈 PR, 버전, 릴리즈 노트 마커 검증
- annotated Git 태그 및 GitHub Release 생성
- 태그/Release 중복 및 부분 실패 상태별 처리
- 동일 SHA·context·state 이벤트의 동시 실행 직렬화

#### Fix

- 신뢰할 수 없는 sender 또는 Vercel 프로젝트 외부의 status 이벤트 차단
- 인접한 릴리즈 노트 마커와 공백뿐인 릴리즈 노트 차단

#### Refactor

- 해당 없음

#### Test

- 실제 workflow의 `run` 스크립트를 추출해 11개 mock 시나리오 검증
- YAML 구조, Bash 문법, Prettier 검사

#### Docs

- 해당 없음

---

## Trade-off

### 한계와 트레이드오프

- 최신 `main` SHA와 일치하는 배포만 릴리즈하므로, 배포 성공 이벤트 처리 전에 새로운 `main` push가 발생하면 이전 배포의 릴리즈는 생성하지 않습니다.
- `status` 이벤트 workflow는 기본 브랜치에 파일이 존재해야 실행되므로, 실제 GitHub Actions 통합 검증은 이 PR이 `develop`에 병합된 이후 가능합니다.
- 실제 Vercel status payload와 조직의 `GITHUB_TOKEN` 쓰기 정책은 첫 운영 실행에서 추가 확인이 필요합니다.

---

## Impact

### 기존 기능에 미치는 영향

- 애플리케이션 코드와 기존 Vercel Git 배포 설정은 변경하지 않습니다.
- `Vercel success + vercel[bot] sender + 현재 프로젝트 target URL + 최신 main SHA + 유효한 릴리즈 PR` 조건을 만족한 경우에만 저장소 태그와 GitHub Release가 생성됩니다.
- workflow에 `contents: write`, `pull-requests: read` 권한이 부여됩니다.
- 잘못된 버전, 누락된 릴리즈 노트 마커, 다른 SHA를 가리키는 기존 태그는 자동 수정하지 않고 실패 로그를 남깁니다.

---

## Edge Cases

### Edge Case 및 실패 시나리오

- 신뢰할 수 없는 sender 또는 현재 Vercel 프로젝트 외부의 target URL: job 실행 안 함
- Preview 또는 과거 SHA: 정상 종료하며 릴리즈를 생성하지 않음
- 유효한 릴리즈 PR이 없거나 여러 개임: 실패
- PR 제목과 본문 버전이 다름: 실패
- 릴리즈 노트 마커가 인접하거나 내부가 공백뿐임: 실패
- 태그와 Release 모두 존재: 중복 생성 없이 성공 종료
- 태그만 존재: 기존 태그 SHA 검증 후 Release 생성 재시도
- Release만 존재: 비정상 상태로 실패
- 기존 태그가 다른 SHA를 가리킴: 실패

---

## Review Points

### 리뷰어가 집중해서 봐야 할 부분

#### 🔴 High

- `Vercel success`와 최신 `main` SHA 비교가 Preview 배포를 확실히 제외하는지
- 배포 SHA에서 `develop → main` 릴리즈 PR을 찾는 조건이 실제 merge 전략에서도 유효한지

#### 🟡 Medium

- 태그/Release 상태별 분기와 부분 실패 재실행이 멱등하게 동작하는지

#### 🟢 Low

- 없음

---

## Validation

### 어떻게 검증했나요?

- [x] YAML 파싱 및 workflow 구조 확인
- [x] workflow 내 Bash 스크립트 문법 검사
- [x] Prettier 검사
- [x] 11개 mock 시나리오 테스트
- [x] `npm run build`
- [ ] `npm run lint` — 기존 `src`의 unrelated lint 오류로 실패
- [ ] 실제 Vercel status 기반 GitHub Actions 실행 — `develop` 병합 후 확인 필요

Closes #187
