### PR TITLE
[cicd-64/e2e] Playwright 기본 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 
 # testing
 /coverage
+/playwright-report/
+/test-results/
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -275,3 +275,17 @@ $ npm install
 ```
 $ npm run dev
 ```
+
+### E2E 테스트 실행하기
+
+최초 실행 시 Chromium을 설치합니다.
+
+```
+$ npx playwright install chromium
+```
+
+Playwright가 개발 서버를 자동으로 실행한 뒤 E2E 테스트를 수행합니다.
+
+```
+$ npm run test:e2e
+```

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test'
+
+test('랜딩 페이지의 주요 콘텐츠를 노출한다', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(page).toHaveTitle('엔빵')
+  await expect(page.getByRole('heading', { level: 1 })).toContainText('엔빵')
+  await expect(
+    page.getByRole('link', { name: '시작하기', exact: true }),
+  ).toHaveAttribute('href', '/login')
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.61.1",
         "@svgr/webpack": "^8.1.0",
         "@types/node": "^20",
         "@types/nprogress": "^0.2.3",
@@ -3906,6 +3907,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -10824,6 +10841,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "postbuild": "next-sitemap",
     "start": "next start",
     "lint": "next lint",
+    "test:e2e": "playwright test",
     "generate-sitemap": "next-sitemap",
     "update-types": "supabase gen types typescript --project-id yyisakaqnaoomehqlyjz --schema public > src/types/supabase.ts"
   },
@@ -32,6 +33,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.61.1",
     "@svgr/webpack": "^8.1.0",
     "@types/node": "^20",
     "@types/nprogress": "^0.2.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:3000'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [
+    [process.env.CI ? 'line' : 'list'],
+    ['html', { open: 'never' }],
+  ],
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: 'npm run dev',
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+})


### PR DESCRIPTION
## Summary

> Playwright 기반 E2E 테스트를 작성하고 로컬에서 실행할 수 있는 기본 환경을 추가합니다.
> Chromium 단일 프로젝트와 랜딩 페이지 smoke 테스트로 최소 실행 기반을 마련합니다.
> 인증, 테스트 데이터, 핵심 사용자 플로우, GitHub Actions 연동은 후속 작업으로 분리합니다.

Closes #172

---

## Why

### 왜 이 작업을 진행했나요?

- 주요 기능 검증이 수동 브라우저 확인에 의존하고 있어 회귀 여부를 반복 가능하게 확인하기 어려웠습니다.
- 로그인, 초대, 그룹 생성, 정산 등 핵심 플로우를 자동화하기 전에 공통으로 사용할 Playwright 실행 환경이 필요했습니다.

---

## Decision

### 어떤 구현 방식을 선택했나요?

- 로컬 개발 서버를 자동으로 실행하는 Playwright 설정과 Chromium 단일 프로젝트를 구성했습니다.
- 로컬 기본 주소는 `http://127.0.0.1:3000`으로 두고, `PLAYWRIGHT_BASE_URL`이 있으면 외부 실행 대상을 사용할 수 있게 했습니다.
- 실패 원인을 재현할 수 있도록 HTML reporter와 실패 시 trace, screenshot, video를 보존합니다.
- 모든 브라우저 조합과 인증 상태 구조를 함께 도입하는 대안은 이번 이슈의 범위를 키우므로 제외했습니다.

---

## Changes

### 무엇이 변경되었나요?

#### Feature

- `@playwright/test` 개발 의존성과 `npm run test:e2e` 스크립트 추가
- Chromium 프로젝트, baseURL, reporter, 재시도 및 진단 자료 설정 추가
- 로컬 개발 서버 자동 실행 및 기존 서버 재사용 설정 추가

#### Fix

- 없음

#### Refactor

- 없음

#### Test

- 랜딩 페이지 제목, 주요 heading, 로그인 링크를 확인하는 smoke 테스트 추가
- Playwright report와 test result 디렉토리를 Git 추적 대상에서 제외

#### Docs

- Chromium 최초 설치 및 E2E 테스트 실행 방법을 README에 추가

---

## Trade-off

### 한계와 트레이드오프

- 실행 시간을 작게 유지하기 위해 Chromium만 검증하며 브라우저 간 호환성은 확인하지 않습니다.
- 인증 상태와 테스트 데이터 준비가 없어 공개 랜딩 페이지만 검증합니다.
- GitHub Actions workflow는 포함하지 않아 현재 E2E 테스트는 로컬에서 수동 실행해야 합니다.

---

## Impact

### 기존 기능에 미치는 영향

- Playwright는 개발 의존성으로만 추가되어 애플리케이션 런타임 동작에는 영향을 주지 않습니다.
- 기본 E2E 실행 시 개발 서버의 3000 포트를 사용합니다. 이미 실행 중인 서버가 있으면 로컬에서는 재사용합니다.
- 운영 환경 설정, secret, Supabase 스키마 및 RLS는 변경하지 않습니다.

---

## Edge Cases

### Edge Case 및 실패 시나리오

- Chromium이 설치되지 않은 환경에서는 `npx playwright install chromium`을 먼저 실행해야 합니다.
- 다른 URL을 검증할 때는 `PLAYWRIGHT_BASE_URL`을 지정하며, 이 경우 로컬 개발 서버를 자동 실행하지 않습니다.
- 테스트 실패 시 `test-results`와 `playwright-report`에 진단 자료가 생성되며 Git에는 포함되지 않습니다.

---

## Review Points

### 리뷰어가 집중해서 봐야 할 부분

#### 🔴 High

- 없음

#### 🟡 Medium

- `webServer` 자동 실행과 `PLAYWRIGHT_BASE_URL` 분기가 이후 CI 구성에도 확장 가능한지
- 실패 시 trace, screenshot, video 보존 수준이 로컬 디버깅에 적절한지

#### 🟢 Low

- 랜딩 페이지 smoke assertion이 기능 변경에 불필요하게 민감하지 않은지

---

## Validation

### 어떻게 검증했나요?

- [ ] 단위 테스트 — 대상 없음
- [x] E2E 테스트 — `npm run test:e2e` (1 passed)
- [ ] 수동 테스트 — 별도 수행하지 않음
- [ ] lint — 전체 lint는 기존 코드의 `any`, Hook 규칙 오류로 실패했으며 신규 Playwright 파일은 ESLint 통과
- [x] typecheck — `npx tsc --noEmit`
- [x] build — `npm run build`
