### PR TITLE
[feature-75/naver-search-advisor] 네이버 서치어드바이저 등록

### DIFF
--- a/llm-wiki/log.md
+++ b/llm-wiki/log.md
@@ -7,3 +7,4 @@
 | 2026-08-13 | 세션 대화 내용을 `raw/2026-08-13-llm-wiki-setup-session-log.md`에 저장 | 구조 결정 근거 보존 | - |
 | 2026-08-13 | GitHub 이슈 #193을 `raw/2026-08-13-github-issue-193-llm-wiki-setup.md`에 저장 | 작업 기획서 원본 보존 | - |
 | 2026-08-13 | 첫 `wiki/` 문서 `llm-wiki-background-and-structure.md` 작성 | 배경, 해결 범위, 구조, 다음 질문 정리 | 이슈 #193 "후속 문서 작성 및 에이전트 연동 범위 정리" 작업 미완료 |
+| 2026-08-13 | GitHub 이슈 #195을 `raw/2026-08-13-github-issue-195-naver-search-advisor.md`에 저장 | 네이버 서치어드바이저 등록 작업 기획서 원본 보존 | 아직 `wiki/` 정리 문서 미작성 |

--- a/llm-wiki/raw/2026-08-13-github-issue-195-naver-search-advisor.md
+++ b/llm-wiki/raw/2026-08-13-github-issue-195-naver-search-advisor.md
@@ -1,0 +1,78 @@
+# GitHub Issue #195: [feature-75/naver-search-advisor] 네이버 서치어드바이저 등록
+
+- URL: https://github.com/andbread/Andbread_Frontend/issues/195
+- 생성일: 2026-08-13T03:08:15Z
+- 라벨: ✨ Feature
+- 담당자: hm1n
+- 프로젝트: KANBAN / Status: Todo
+
+---
+
+## Summary
+
+> 3줄 이내로 이번 작업을 요약합니다.
+
+- 네이버 서치어드바이저에 사이트를 등록하고 소유 확인을 완료합니다.
+- 소유 확인은 HTML 태그 방식을 사용하며, `layout.tsx`의 metadata에 검증 태그를 추가합니다.
+- sitemap 제출 및 robots.txt의 네이버 크롤러 접근 허용 여부를 함께 확인합니다.
+
+---
+
+## Why
+
+### 해결하려는 문제가 무엇인가요?
+
+- 현재 엔빵 서비스는 네이버 서치어드바이저에 등록되어 있지 않아, 네이버 검색 결과에 노출되지 않거나 색인이 지연될 수 있습니다.
+- 국내 검색 트래픽 비중이 높은 네이버 특성상, 서치어드바이저 미등록 시 검색 유입 채널을 놓치게 됩니다.
+- 해결하지 않으면 신규 페이지(랜딩페이지, sitemap 등)가 네이버에 정상적으로 색인되지 않아 검색 유입 기회를 잃습니다.
+
+---
+
+## Goal
+
+### 완료되면 무엇이 달라지나요?
+
+- 네이버 서치어드바이저에 사이트가 등록되고 소유 확인이 완료된 상태가 됩니다.
+- 네이버 서치어드바이저를 통해 sitemap이 제출되고, robots.txt가 네이버 크롤러(Yeti)의 접근을 허용하는지 확인됩니다.
+- Non-goal: 네이버 검색 노출 순위 최적화, 키워드 전략 수립은 이번 작업 범위에 포함하지 않습니다.
+
+---
+
+## Approach
+
+### 어떻게 해결할 계획인가요?
+
+- 네이버 서치어드바이저(https://searchadvisor.naver.com)에 사이트(`https://www.nbread.co.kr`)를 등록합니다.
+- 소유 확인은 HTML 태그 방식을 사용합니다. 발급받은 검증 코드를 `src/app/layout.tsx`의 `metadata.verification.other`에 `naver-site-verification` 키로 추가합니다.
+  - 참고: 현재 `metadata`에는 검증 관련 필드가 없어 신규로 추가합니다.
+- 배포 후 서치어드바이저에서 소유 확인을 완료합니다.
+- 기존 `public/robots.txt`, `public/sitemap.xml`을 서치어드바이저에 제출하고, 네이버 크롤러 접근이 허용되어 있는지 확인합니다.
+  - 현재 `robots.txt`는 `User-agent: *`로 전체 허용/비허용 규칙을 두고 있어 별도 Yeti 규칙은 없는 상태입니다. 문제가 없는지 확인이 필요합니다.
+- 검토한 대안: 메타 태그 대신 HTML 파일 업로드 방식도 가능하나, 코드베이스 관리 일관성을 위해 메타 태그 방식을 선택합니다.
+
+---
+
+## Tasks
+
+- [ ] 네이버 서치어드바이저 사이트 등록 및 HTML 태그 검증 코드 발급
+- [ ] `layout.tsx`의 `metadata.verification.other`에 `naver-site-verification` 태그 추가
+- [ ] 배포 후 서치어드바이저에서 소유 확인 완료
+- [ ] sitemap.xml 제출
+- [ ] robots.txt의 네이버 크롤러(Yeti) 접근 허용 여부 확인
+
+---
+
+## Constraints
+
+- 기존 Google 등 다른 검색엔진 소유 확인 방식과 충돌하지 않아야 합니다. (확인 필요: 현재 다른 verification 태그 없음)
+- `robots.txt`에서 이미 정의된 `Disallow` 경로(`/auth/`, `/mypage` 등)는 변경하지 않습니다.
+- 검증 코드는 공개 메타 태그 값으로, Secret으로 취급하지 않되 오입력 시 소유 확인이 실패하므로 정확히 반영해야 합니다.
+
+---
+
+## Definition of Done
+
+- [ ] 기능 동작 확인 (네이버 서치어드바이저 소유 확인 완료 상태)
+- [ ] 테스트 완료 (배포 후 실제 페이지 소스에 검증 태그 노출 확인)
+- [ ] lint / typecheck 통과
+- [ ] 문서 업데이트 (필요 시)

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -26,9 +26,6 @@ module.exports = {
       {
         userAgent: '*',
         allow: '/',
-      },
-      {
-        userAgent: '*',
         disallow: [
           '/auth/',
           '/calendar',

--- a/public/navera5d9205227fb535d80bc4ce31d3ee176.html
+++ b/public/navera5d9205227fb535d80bc4ce31d3ee176.html
@@ -1,0 +1,1 @@
+naver-site-verification: navera5d9205227fb535d80bc4ce31d3ee176.html

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,9 +1,6 @@
 # *
 User-agent: *
 Allow: /
-
-# *
-User-agent: *
 Disallow: /auth/
 Disallow: /calendar
 Disallow: /friendList

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://www.nbread.co.kr/ios-guide</loc><lastmod>2026-07-10T09:10:58.779Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.nbread.co.kr</loc><lastmod>2026-07-10T09:10:58.780Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.nbread.co.kr/privacy-policy</loc><lastmod>2026-07-10T09:10:58.780Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://www.nbread.co.kr/terms-of-service</loc><lastmod>2026-07-10T09:10:58.780Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.nbread.co.kr/privacy-policy</loc><lastmod>2026-08-13T07:04:00.986Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.nbread.co.kr/terms-of-service</loc><lastmod>2026-08-13T07:04:00.987Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.nbread.co.kr</loc><lastmod>2026-08-13T07:04:00.987Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://www.nbread.co.kr/ios-guide</loc><lastmod>2026-08-13T07:04:00.987Z</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
## Summary

- 네이버 서치어드바이저 사이트 소유 확인용 HTML 파일을 `public/`에 추가했습니다.
- robots.txt에 중복 작성되어 있던 `User-agent: *` 그룹을 하나로 병합했습니다.

---

## Why

### 왜 이 작업을 진행했나요?

- 엔빵 사이트가 네이버 서치어드바이저에 등록되어 있지 않아 네이버 검색 결과 노출이 지연되고 색인도 늦어지는 문제가 있었습니다. 관련 이슈는 #195입니다.
- 서치어드바이저 실시간 진단에서 robots.txt가 존재하지 않는다고 표시되었습니다. curl로 직접 확인해 보니 서버는 상태 코드 200과 `text/plain` 형식으로 정상 응답하고 있었습니다. 다만 robots.txt 파일 안에서 `User-agent: *` 그룹이 Allow 그룹과 Disallow 그룹으로 나뉘어 두 번 작성되어 있었습니다. 이런 구조는 일부 크롤러 파서가 뒤쪽 Disallow 그룹을 무시할 위험이 있어 함께 정리했습니다.

---

## Decision

### 어떤 구현 방식을 선택했나요?

- 이슈에는 메타 태그 방식이 제안되어 있었지만 실제로 네이버 서치어드바이저에서 발급받은 소유 확인 방식은 HTML 파일 업로드 방식이었습니다. 그래서 발급받은 파일을 `public/` 디렉토리 루트에 그대로 배치했습니다. Next.js는 `public/` 하위 파일을 URL 루트에 정적으로 서빙하기 때문에 별도 라우팅 설정 없이 접근할 수 있습니다.
- robots.txt는 기존에 `User-agent: *` 그룹이 두 개로 나뉘어 있었습니다. 이 두 그룹을 하나로 병합했습니다. 기존에 정의된 Disallow 경로 목록은 그대로 유지했습니다.
- 메타 태그 방식도 검토했지만 실제 발급된 검증 방식이 HTML 파일이었기 때문에 이슈 원안 대신 발급받은 방식을 그대로 반영했습니다.

---

## Changes

### 무엇이 변경되었나요?

#### Feature

- 네이버 서치어드바이저 소유 확인용 HTML 파일을 추가했습니다. 파일 경로는 `public/navera5d9205227fb535d80bc4ce31d3ee176.html`입니다.

#### Fix

- `public/robots.txt`에서 중복된 `User-agent: *` 그룹을 병합했습니다.

#### Refactor

-

#### Test

-

#### Docs

-

---

## Trade-off

### 한계와 트레이드오프

- 소유 확인 완료 여부, sitemap 제출, Yeti 크롤러 접근 허용 여부에 대한 최종 확인은 네이버 서치어드바이저 대시보드에서 수동으로 진행해야 합니다. 이번 PR의 코드 변경 범위에는 포함하지 않았습니다.

---

## Impact

### 기존 기능에 미치는 영향

- 기존 Disallow 경로는 그대로 유지했습니다. `/auth/`와 `/mypage` 등 기존 접근 정책은 변경하지 않았습니다.
- robots.txt 그룹 병합은 규칙 내용을 바꾸지 않고 구조만 정리한 것이므로 기존 검색엔진 수집 동작에는 영향이 없습니다.
- 정적 파일을 추가한 것뿐이므로 기존 라우팅이나 빌드 과정에는 영향이 없습니다.

---

## Edge Cases

### Edge Case 및 실패 시나리오

- 서치어드바이저 진단 결과가 캐시되어 있을 수 있습니다. 배포 후 대시보드에서 robots.txt 수집 요청을 다시 눌러 재검증해야 합니다.

---

## Review Points

### 리뷰어가 집중해서 봐야 할 부분

#### 🔴 High

-

#### 🟡 Medium

- robots.txt 그룹을 병합한 결과가 기존 Disallow 규칙의 의도를 그대로 보존하는지 확인해 주세요.

#### 🟢 Low

- 소유 확인용 HTML 파일이 다른 정적 자산과 충돌하지 않는지 확인해 주세요.

---

## Validation

### 어떻게 검증했나요?

- [x] 수동 테스트를 진행했습니다. curl로 `https://www.nbread.co.kr/robots.txt`에 직접 요청해 상태 코드 200과 리다이렉트 없음을 확인했습니다.
- [x] lint를 실행했습니다. 이번 변경과 무관한 기존 경고 외에 새로운 오류는 없었습니다.
- [ ] 단위 테스트
- [ ] E2E 테스트
- [ ] typecheck