### PR TITLE
[fix-204/faq-accordion-a11y] FAQ 아코디언 자바스크립트 비활성 환경 접근성 수정

### DIFF
--- a/src/components/landing/FaqAccordionItem.tsx
+++ b/src/components/landing/FaqAccordionItem.tsx
@@ -59,8 +59,7 @@ const FaqAccordionItem = ({
 
       <div
         id={contentId}
-        aria-hidden={!isOpen}
-        className="grid transition-[grid-template-rows] duration-300 ease-out"
+        className="faq-answer-panel grid transition-[grid-template-rows] duration-300 ease-out"
         style={{ gridTemplateRows: isOpen ? '1fr' : '0fr' }}
       >
         <div className="overflow-hidden">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -300,4 +300,8 @@ a {
     transform: none !important;
     transition: none !important;
   }
+
+  .faq-answer-panel {
+    grid-template-rows: 1fr !important;
+  }
 }


### PR DESCRIPTION
## Summary

- 자바스크립트 비활성 환경에서 FAQ 아코디언 답변이 시각적으로도, 접근성 트리에서도 노출되지 않던 문제를 수정했습니다.
- `aria-hidden` 제거와 `scripting: none` CSS 규칙 추가로, 자바스크립트/스크린리더 유무 4가지 조합 모두에서 답변에 접근 가능해집니다.

---

## Why

### 왜 이 작업을 진행했나요?

- PR #203(v2.4.0 릴리즈 PR)에서 Codex 코드 리뷰(P2)가 `FaqAccordionItem.tsx`의 접근성 문제를 지적했습니다: 자바스크립트가 없으면 하이드레이션이 일어나지 않아 `isOpen`의 SSR 초기값이 그대로 굳어지고, `defaultOpen`이 없는 3개 항목의 답변이 `grid-template-rows: 0fr`로 영구히 접힌 채 노출되지 않습니다.
- 이는 FAQ 기능(#202) 구현 당시 명시했던 목표("답변 본문은 열림/닫힘 상태와 무관하게 항상 서버에서 렌더링되며, 검색 로봇과 자바스크립트 미지원 환경에서도 콘텐츠를 읽을 수 있다")와 실제 동작이 어긋난 상태였습니다.
- v2.4.0으로 릴리즈된 기능이라 지금 바로잡지 않으면 자바스크립트 제한 환경/스크린리더 사용자가 FAQ 답변 대부분에 접근하지 못하는 상태가 유지됩니다.

---

## Decision

### 어떤 구현 방식을 선택했나요?

- 답변 패널 div에 고정 class(`faq-answer-panel`)를 부여하고, `globals.css`의 `@media (scripting: none)` 블록에 `grid-template-rows: 1fr !important` 규칙을 추가해 무자바스크립트 환경에서 시각적으로 항상 펼쳐지도록 했습니다. 기존에 같은 미디어쿼리로 `.reveal-on-scroll`을 처리하던 패턴을 그대로 재사용했습니다.
- 답변 패널의 `aria-hidden={!isOpen}`을 제거했습니다. 이 값은 SSR 시점에 고정되어 자바스크립트가 없으면 절대 바뀌지 않는데, CSS로는 `aria-hidden` 같은 DOM 속성을 제어할 수 없어 CSS 수정만으로는 스크린리더+무자바스크립트 조합을 해결할 수 없었습니다. 속성을 아예 제거해 열림 상태와 무관하게 항상 접근성 트리에 노출되도록 했습니다.
- 검토한 대안: 자바스크립트 실행 여부에 따라 `aria-hidden`을 다르게 렌더링하는 방법은 SSR 시점에 클라이언트의 자바스크립트 실행 여부를 알 수 없어 불가능합니다. 아코디언 구조를 native `<details>`/`<summary>`로 전환하는 방법은 PR #202에서 개폐 트랜지션의 크로스브라우저 지원 문제로 이미 검토 후 제외되어, 이번 범위에서 다시 고려하지 않았습니다.

---

## Changes

### 무엇이 변경되었나요?

#### Fix

- `FaqAccordionItem.tsx`: 답변 패널의 `aria-hidden={!isOpen}` 제거, `faq-answer-panel` class 추가
- `globals.css`: `@media (scripting: none)`에 `.faq-answer-panel` 대상 `grid-template-rows` 강제 확장 규칙 추가

---

## Trade-off

### 한계와 트레이드오프

- `aria-hidden`을 제거하면서, 자바스크립트가 켜진 상태에서도 스크린리더 사용자는 시각적으로 닫힌 패널의 답변까지 항상 들을 수 있게 됩니다. 일반적인 ARIA 아코디언 패턴(닫힌 패널은 접근성 트리에서도 숨김)과는 다르지만, FAQ 기능의 기존 설계 목표(콘텐츠 항상 노출)를 따른 의도적인 선택입니다. 답변이 짧은 텍스트라 실사용 영향은 크지 않다고 판단했습니다.

---

## Impact

### 기존 기능에 미치는 영향

- 자바스크립트가 켜진 상태의 시각적 개폐 트랜지션 동작은 변경하지 않았습니다.
- `FaqAccordionItem`과 `globals.css`의 `scripting: none` 블록 외 다른 컴포넌트/화면에는 영향이 없습니다.
- 새 의존성을 추가하지 않았습니다.

---

## Edge Cases

### Edge Case 및 실패 시나리오

- 자바스크립트 비활성 환경: 4개 항목 모두 CSS로 시각적으로 펼쳐지고, `aria-hidden`이 없어 접근성 트리에도 항상 노출됩니다.
- 자바스크립트 활성 환경: 클릭 토글은 기존과 동일하게 동작하며, `aria-hidden`만 제거되어 스크린리더가 닫힌 패널 답변도 함께 읽을 수 있습니다(Trade-off 참고).

---

## Review Points

### 리뷰어가 집중해서 봐야 할 부분

#### 🔴 High

- `aria-hidden` 제거로 인한 접근성 동작 변화(스크린리더가 닫힌 패널도 읽음)가 이 프로젝트 기준에서 허용 가능한 트레이드오프인지

#### 🟡 Medium

- `@media (scripting: none)` 규칙이 실제 자바스크립트 비활성 브라우저에서 의도대로 적용되는지

---

## Validation

### 어떻게 검증했나요?

- [ ] 단위 테스트
- [ ] E2E 테스트
- [x] 수동 테스트 (dev 서버 + Playwright: SSR HTML class 확인, JS 켜진 상태 클릭 토글 확인, 닫힌 패널도 접근성 트리에 노출되는지 스냅샷 확인)
- [x] lint
- [x] typecheck (npm run build 타입체크 통과, 정적 페이지 생성 단계는 로컬 `.env` 미비로 별개 실패)
